### PR TITLE
Visor de lecciones

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -66,6 +66,6 @@ class CourseController extends Controller
     public function enroll(Course $course) {
         $course->students()->sync(auth()->user()->id);
 
-        return redirect()->route('courses.status', $course);
+        return redirect()->route('courses.learn', $course);
     }
 }

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -68,9 +68,4 @@ class CourseController extends Controller
 
         return redirect()->route('courses.status', $course);
     }
-
-    public function learn(Course $course)
-    {
-        return view('courses.learn', compact('course'));
-    }
 }

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -68,4 +68,9 @@ class CourseController extends Controller
 
         return redirect()->route('courses.status', $course);
     }
+
+    public function learn(Course $course)
+    {
+        return view('courses.learn', compact('course'));
+    }
 }

--- a/app/Livewire/CourseLearn.php
+++ b/app/Livewire/CourseLearn.php
@@ -25,7 +25,8 @@ class CourseLearn extends Component
             $this->lesson = $lesson;
         } else {
             foreach ($course->lessons as $lesson) {
-                if (!$lesson->completed) {
+                /* Si la lección no está, o se trata de la última lección */
+                if (!$lesson->completed || $course->lessons->last()->id == $lesson->id) {
                     $this->lesson = $lesson;
                     break;
                 }
@@ -42,5 +43,26 @@ class CourseLearn extends Component
     public function render()
     {
         return view('livewire.course-learn');
+    }
+
+    public function toggleCompleted()
+    {
+        if ($this->lesson->completed) {
+            $this->lesson->users()->detach(auth()->user()->id);
+        } else {
+            $this->lesson->users()->attach(auth()->user()->id);
+        }
+    }
+
+    public function getAdvanceProperty()
+    {
+        $i = 0;
+        foreach ($this->course->lessons as $lesson) {
+            if ($lesson->completed) {
+                $i++;
+            }
+        }
+        $advance = ($i * 100) / ($this->course->lessons->count());
+        return round($advance, 2);
     }
 }

--- a/app/Livewire/CourseLearn.php
+++ b/app/Livewire/CourseLearn.php
@@ -11,11 +11,16 @@ class CourseLearn extends Component
 
     public Course $course;
     public Lesson $lesson;
+    public $index;
+    public $previous;
+    public $next;
 
     public function mount(Course $course, $lesson = null)
     {
         $this->course = $course;
 
+        /* Si llegamos sin el parámetro lesson, buscamos la última lección pendiente del usuario
+            y redirigimos a la ruta con el parámetro lesson */
         if ($lesson) {
             $this->lesson = $lesson;
         } else {
@@ -27,6 +32,11 @@ class CourseLearn extends Component
             }
             redirect()->route('courses.learn', [$this->course, $this->lesson]);
         }
+
+        /* Obtenemos el índice de la lección, y su contiguas */
+        $this->index = $course->lessons->pluck('id')->search($this->lesson->id);
+        $this->previous = $course->lessons[$this->index - 1] ?? null;
+        $this->next = $course->lessons[$this->index + 1] ?? null;
     }
 
     public function render()

--- a/app/Livewire/CourseLearn.php
+++ b/app/Livewire/CourseLearn.php
@@ -2,10 +2,19 @@
 
 namespace App\Livewire;
 
+use App\Models\Course;
 use Livewire\Component;
 
 class CourseLearn extends Component
 {
+
+    public $course;
+
+    public function mount(Course $course)
+    {
+        $this->course = $course;
+    }
+
     public function render()
     {
         return view('livewire.course-learn');

--- a/app/Livewire/CourseLearn.php
+++ b/app/Livewire/CourseLearn.php
@@ -3,16 +3,30 @@
 namespace App\Livewire;
 
 use App\Models\Course;
+use App\Models\Lesson;
 use Livewire\Component;
 
 class CourseLearn extends Component
 {
 
-    public $course;
+    public Course $course;
+    public Lesson $lesson;
 
-    public function mount(Course $course)
+    public function mount(Course $course, $lesson = null)
     {
         $this->course = $course;
+
+        if ($lesson) {
+            $this->lesson = $lesson;
+        } else {
+            foreach ($course->lessons as $lesson) {
+                if (!$lesson->completed) {
+                    $this->lesson = $lesson;
+                    break;
+                }
+            }
+            redirect()->route('courses.learn', [$this->course, $this->lesson]);
+        }
     }
 
     public function render()

--- a/app/Livewire/CourseLearn.php
+++ b/app/Livewire/CourseLearn.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class CourseLearn extends Component
+{
+    public function render()
+    {
+        return view('livewire.course-learn');
+    }
+}

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -106,4 +106,9 @@ class Course extends Model
     {
         return $this->morphOne(Image::class, 'imageable');
     }
+
+    public function lessons()
+    {
+        return $this->hasManyThrough(Lesson::class, Section::class);
+    }
 }

--- a/app/Models/Lesson.php
+++ b/app/Models/Lesson.php
@@ -9,6 +9,11 @@ class Lesson extends Model
 {
     use HasFactory;
 
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
+
     /**
      * Devuelve true si la lección actual está completada, false en caso contrario.
      */

--- a/app/Models/Lesson.php
+++ b/app/Models/Lesson.php
@@ -9,6 +9,14 @@ class Lesson extends Model
 {
     use HasFactory;
 
+    /**
+     * Devuelve true si la lección actual está completada, false en caso contrario.
+     */
+    public function getCompletedAttribute()
+    {
+        return $this->users->contains(auth()->user()->id);
+    }
+
     public function section()
     {
         return $this->belongsTo(Section::class);

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -1,0 +1,159 @@
+<?php
+
+return [
+
+    /*
+    |---------------------------------------------------------------------------
+    | Class Namespace
+    |---------------------------------------------------------------------------
+    |
+    | This value sets the root class namespace for Livewire component classes in
+    | your application. This value will change where component auto-discovery
+    | finds components. It's also referenced by the file creation commands.
+    |
+    */
+
+    'class_namespace' => 'App\\Livewire',
+
+    /*
+    |---------------------------------------------------------------------------
+    | View Path
+    |---------------------------------------------------------------------------
+    |
+    | This value is used to specify where Livewire component Blade templates are
+    | stored when running file creation commands like `artisan make:livewire`.
+    | It is also used if you choose to omit a component's render() method.
+    |
+    */
+
+    'view_path' => resource_path('views/livewire'),
+
+    /*
+    |---------------------------------------------------------------------------
+    | Layout
+    |---------------------------------------------------------------------------
+    | The view that will be used as the layout when rendering a single component
+    | as an entire page via `Route::get('/post/create', CreatePost::class);`.
+    | In this case, the view returned by CreatePost will render into $slot.
+    |
+    */
+
+    'layout' => 'layouts.app',
+
+    /*
+    |---------------------------------------------------------------------------
+    | Lazy Loading Placeholder
+    |---------------------------------------------------------------------------
+    | Livewire allows you to lazy load components that would otherwise slow down
+    | the initial page load. Every component can have a custom placeholder or
+    | you can define the default placeholder view for all components below.
+    |
+    */
+
+    'lazy_placeholder' => null,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Temporary File Uploads
+    |---------------------------------------------------------------------------
+    |
+    | Livewire handles file uploads by storing uploads in a temporary directory
+    | before the file is stored permanently. All file uploads are directed to
+    | a global endpoint for temporary storage. You may configure this below:
+    |
+    */
+
+    'temporary_file_upload' => [
+        'disk' => null,        // Example: 'local', 's3'              | Default: 'default'
+        'rules' => null,       // Example: ['file', 'mimes:png,jpg']  | Default: ['required', 'file', 'max:12288'] (12MB)
+        'directory' => null,   // Example: 'tmp'                      | Default: 'livewire-tmp'
+        'middleware' => null,  // Example: 'throttle:5,1'             | Default: 'throttle:60,1'
+        'preview_mimes' => [   // Supported file types for temporary pre-signed file URLs...
+            'png', 'gif', 'bmp', 'svg', 'wav', 'mp4',
+            'mov', 'avi', 'wmv', 'mp3', 'm4a',
+            'jpg', 'jpeg', 'mpga', 'webp', 'wma',
+        ],
+        'max_upload_time' => 5, // Max duration (in minutes) before an upload is invalidated...
+    ],
+
+    /*
+    |---------------------------------------------------------------------------
+    | Render On Redirect
+    |---------------------------------------------------------------------------
+    |
+    | This value determines if Livewire will run a component's `render()` method
+    | after a redirect has been triggered using something like `redirect(...)`
+    | Setting this to true will render the view once more before redirecting
+    |
+    */
+
+    'render_on_redirect' => false,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Eloquent Model Binding
+    |---------------------------------------------------------------------------
+    |
+    | Previous versions of Livewire supported binding directly to eloquent model
+    | properties using wire:model by default. However, this behavior has been
+    | deemed too "magical" and has therefore been put under a feature flag.
+    |
+    */
+
+    'legacy_model_binding' => false,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Auto-inject Frontend Assets
+    |---------------------------------------------------------------------------
+    |
+    | By default, Livewire automatically injects its JavaScript and CSS into the
+    | <head> and <body> of pages containing Livewire components. By disabling
+    | this behavior, you need to use @livewireStyles and @livewireScripts.
+    |
+    */
+
+    'inject_assets' => true,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Navigate (SPA mode)
+    |---------------------------------------------------------------------------
+    |
+    | By adding `wire:navigate` to links in your Livewire application, Livewire
+    | will prevent the default link handling and instead request those pages
+    | via AJAX, creating an SPA-like effect. Configure this behavior here.
+    |
+    */
+
+    'navigate' => [
+        'show_progress_bar' => true,
+        'progress_bar_color' => '#2299dd',
+    ],
+
+    /*
+    |---------------------------------------------------------------------------
+    | HTML Morph Markers
+    |---------------------------------------------------------------------------
+    |
+    | Livewire intelligently "morphs" existing HTML into the newly rendered HTML
+    | after each update. To make this process more reliable, Livewire injects
+    | "markers" into the rendered Blade surrounding @if, @class & @foreach.
+    |
+    */
+
+    'inject_morph_markers' => true,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Pagination Theme
+    |---------------------------------------------------------------------------
+    |
+    | When enabling Livewire's pagination feature by using the `WithPagination`
+    | trait, Livewire will use Tailwind templates to render pagination views
+    | on the page. If you want Bootstrap CSS, you can specify: "bootstrap"
+    |
+    */
+
+    'pagination_theme' => 'tailwind',
+];

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,6 +1,8 @@
+@import "custom.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
 
 [x-cloak] {
     display: none;

--- a/resources/css/custom.css
+++ b/resources/css/custom.css
@@ -1,0 +1,14 @@
+.embed-responsive {
+  position: relative;
+  overflow: hidden;
+  padding-top: 50%;
+}
+
+.embed-responsive iframe {
+  position:absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/resources/views/courses/learn.blade.php
+++ b/resources/views/courses/learn.blade.php
@@ -1,3 +1,0 @@
-<x-app-layout>
-    @livewire('course-learn')
-</x-app-layout>

--- a/resources/views/courses/learn.blade.php
+++ b/resources/views/courses/learn.blade.php
@@ -1,0 +1,3 @@
+<x-app-layout>
+    @livewire('course-learn')
+</x-app-layout>

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -182,7 +182,7 @@
 
                     @can('enrolled', $course)
                         <x-link-button class="w-full justify-center rounded-md !text-sm h-12 mt-4 bg-teal-500 hover:bg-teal-700"
-                                href="{{ route('courses.status', $course) }}">
+                                href="{{ route('courses.learn', $course) }}">
                             Continuar con el curso
                         </x-link-button>
                     @else

--- a/resources/views/livewire/course-learn.blade.php
+++ b/resources/views/livewire/course-learn.blade.php
@@ -3,7 +3,7 @@
 
         {{-- Columna izquierda--}}
         <div class="col-span-2">
-
+            {{ $lesson }}
         </div>
 
         {{-- Columna derecha--}}

--- a/resources/views/livewire/course-learn.blade.php
+++ b/resources/views/livewire/course-learn.blade.php
@@ -4,11 +4,27 @@
         {{-- Columna izquierda--}}
         <div class="col-span-2">
 
-            {!! $lesson->iframe !!}
+            <div class="embed-responsive rounded">
+                {!! $lesson->iframe !!}
+            </div>
+
             <h1 class="text-2xl text-gray-700 font-bold">
                 {{ $lesson->title }}
             </h1>
-            <div>
+
+            @if ($lesson->description)
+                <div class="text-gray-700">
+                    {{ $lesson->description->description }}
+                </div>
+            @endif
+
+            <label class="relative inline-flex items-center mt-2 mb-5 cursor-pointer">
+                <input type="checkbox" value="" class="sr-only peer">
+                <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-indigo-300 dark:peer-focus:ring-indigo-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-indigo-600"></div>
+                <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Marcar lección como completa</span>
+            </label>
+
+            <div class="flex justify-between text-gray-700 bg-white shadow-lg rounded-lg p-4">
                 @if ($previous)
                 <x-link-button href="{{route('courses.learn', [$course, $previous])}}">
                     Anterior

--- a/resources/views/livewire/course-learn.blade.php
+++ b/resources/views/livewire/course-learn.blade.php
@@ -3,7 +3,32 @@
 
         {{-- Columna izquierda--}}
         <div class="col-span-2">
-            {{ $lesson }}
+
+            {!! $lesson->iframe !!}
+            <h1 class="text-2xl text-gray-700 font-bold">
+                {{ $lesson->title }}
+            </h1>
+            <div>
+                @if ($previous)
+                <x-link-button href="{{route('courses.learn', [$course, $previous])}}">
+                    Anterior
+                </x-link-button>
+                @else
+                <x-link-button href="#" class="bg-gray-300 hover:bg-gray-300 focus:bg-gray-300 active:bg-gray-300 cursor-default" disabled>
+                    Anterior
+                </x-link-button>
+                @endif
+
+                @if ($next)
+                <x-link-button href="{{route('courses.learn', [$course, $next])}}">
+                    Siguiente
+                </x-link-button>
+                @else
+                <x-link-button href="#" class="bg-gray-300 hover:bg-gray-300 focus:bg-gray-300 active:bg-gray-300 cursor-default" disabled>
+                    Siguiente
+                </x-link-button>
+                @endif
+            </div>
         </div>
 
         {{-- Columna derecha--}}
@@ -26,7 +51,7 @@
                 </div>
             </div>
 
-            <ul>
+            <ul class="mt-4">
                 @foreach ($course->sections as $section)
                     <li>
                         <span class="font-bold text-rose-600">[{{ $section->id }}]</span>
@@ -37,7 +62,7 @@
                             @foreach ($section->lessons as $lesson)
                                 <li>
                                     <i class="fa-solid fa-play-circle mr-2"></i>
-                                    <a href="">
+                                    <a href="{{ route('courses.learn', [$course, $lesson]) }}">
                                         <span class="font-bold text-rose-400">[{{ $lesson->id }}]</span>
                                         {{ Str::limit($lesson->title, 30) }}
                                     </a>

--- a/resources/views/livewire/course-learn.blade.php
+++ b/resources/views/livewire/course-learn.blade.php
@@ -1,3 +1,3 @@
 <div>
-    <h1>Visor de lecciones</h1>
+    <h1>Visor de lecciones del curso: {{ $course->title }}</h1>
 </div>

--- a/resources/views/livewire/course-learn.blade.php
+++ b/resources/views/livewire/course-learn.blade.php
@@ -1,3 +1,55 @@
-<div>
-    <h1>Visor de lecciones del curso: {{ $course->title }}</h1>
+<div class="mt-8">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-3 gap-8">
+
+        {{-- Columna izquierda--}}
+        <div class="col-span-2">
+
+        </div>
+
+        {{-- Columna derecha--}}
+        <div class="text-gray-700 bg-white shadow-lg rounded p-4">
+            <p class="text-xl font-bold text-center">{{ $course->title }}</p>
+
+            <div class="flex items-center mt-2">
+                <figure>
+                    <img class="h-16 w-16 object-cover rounded-full shadow-lg" src="{{ $course->teacher->profile_photo_url }}" alt="{{ $course->teacher->name }}">
+                </figure>
+                <div class="ml-2">
+                    <p>Realizado por</p>
+                    <h3 class="text-3xl font-bold">
+                        {{ $course->teacher->name }}
+                    </h3>
+                    <a class="text-sm text-teal-500 hover:text-teal-700"
+                            href="">
+                        {{'@' . Str::slug($course->teacher->name, '')}}
+                    </a>
+                </div>
+            </div>
+
+            <ul>
+                @foreach ($course->sections as $section)
+                    <li>
+                        <span class="font-bold text-rose-600">[{{ $section->id }}]</span>
+                        <a class="font-bold" href="">
+                            {{ Str::limit($section->title, 30) }}
+                        </a>
+                        <ul>
+                            @foreach ($section->lessons as $lesson)
+                                <li>
+                                    <i class="fa-solid fa-play-circle mr-2"></i>
+                                    <a href="">
+                                        <span class="font-bold text-rose-400">[{{ $lesson->id }}]</span>
+                                        {{ Str::limit($lesson->title, 30) }}
+                                    </a>
+                                </li>
+
+                            @endforeach
+                        </ul>
+                    </li>
+                @endforeach
+            </ul>
+
+        </div>
+
+    </div>
 </div>

--- a/resources/views/livewire/course-learn.blade.php
+++ b/resources/views/livewire/course-learn.blade.php
@@ -1,15 +1,15 @@
 <div class="mt-8">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-3 gap-8">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 lg:grid-cols-3 lg:gap-8">
 
         {{-- Columna izquierda--}}
-        <div class="col-span-2">
+        <div class="col-span-2 mb-6">
 
-            <div class="embed-responsive rounded">
+            <div class="embed-responsive rounded mb-4">
                 {!! $lesson->iframe !!}
             </div>
 
             <h1 class="text-2xl text-gray-700 font-bold">
-                {{ $lesson->title }}
+                <span>{{$index+1}}. </span>{{ $lesson->title }}
             </h1>
 
             @if ($lesson->description)
@@ -21,7 +21,7 @@
             <label class="relative inline-flex items-center mt-2 mb-5 cursor-pointer">
                 <input type="checkbox" value="" class="sr-only peer">
                 <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-indigo-300 dark:peer-focus:ring-indigo-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-indigo-600"></div>
-                <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Marcar lección como completa</span>
+                <span class="ms-3 text-base font-medium text-gray-700 dark:text-gray-300">Marcar lección como completa</span>
             </label>
 
             <div class="flex justify-between text-gray-700 bg-white shadow-lg rounded-lg p-4">
@@ -69,18 +69,38 @@
 
             <ul class="mt-4">
                 @foreach ($course->sections as $section)
-                    <li>
-                        <span class="font-bold text-rose-600">[{{ $section->id }}]</span>
-                        <a class="font-bold" href="">
-                            {{ Str::limit($section->title, 30) }}
+                    <li class="text-gray-700 mb-4">
+                        {{-- <span class="font-bold text-rose-600">[{{ $section->id }}]</span> --}}
+                        <a class="inline-block mb-2 font-bold" href="">
+                            {{ Str::limit($section->title, 40) }}
                         </a>
                         <ul>
                             @foreach ($section->lessons as $lesson)
-                                <li>
-                                    <i class="fa-solid fa-play-circle mr-2"></i>
-                                    <a href="{{ route('courses.learn', [$course, $lesson]) }}">
-                                        <span class="font-bold text-rose-400">[{{ $lesson->id }}]</span>
-                                        {{ Str::limit($lesson->title, 30) }}
+                                <li class="flex">
+                                    <div>
+                                        <a href="{{ route('courses.learn', [$course, $lesson]) }}">
+
+                                        @if ($lesson->completed)
+                                            @if ($lesson->id == $this->lesson->id)
+                                                <span class="inline-block w-5 h-5 rounded-full border-4 border-indigo-400 mt-1 mr-2"></span>
+                                            @else
+                                                <span class="inline-block w-5 h-5 rounded-full bg-indigo-400 mt-1 mr-2"></span>
+                                            @endif
+                                        @else
+
+                                            @if ($lesson->id == $this->lesson->id)
+                                                <span class="inline-block w-5 h-5 rounded-full border-4 border-gray-500 mt-1 mr-2"></span>
+                                            @else
+                                                <span class="inline-block w-5 h-5 rounded-full bg-gray-500 mt-1 mr-2"></span>
+                                            @endif
+
+                                        @endif
+
+                                    </div>
+                                    {{-- <i class="fa-solid fa-play-circle mr-2"></i> --}}
+
+                                        {{-- <span class="font-bold text-rose-400">[{{ $lesson->id }}]</span> --}}
+                                        {{ Str::limit($lesson->title, 40) }}
                                     </a>
                                 </li>
 

--- a/resources/views/livewire/course-learn.blade.php
+++ b/resources/views/livewire/course-learn.blade.php
@@ -1,0 +1,3 @@
+<div>
+    <h1>Visor de lecciones</h1>
+</div>

--- a/resources/views/livewire/course-learn.blade.php
+++ b/resources/views/livewire/course-learn.blade.php
@@ -1,8 +1,8 @@
 <div class="mt-8">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 lg:grid-cols-3 lg:gap-8">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 lg:grid-cols-3 gap-8">
 
         {{-- Columna izquierda--}}
-        <div class="col-span-2 mb-6">
+        <div class="lg:col-span-2 mb-6">
 
             <div class="embed-responsive rounded mb-4">
                 {!! $lesson->iframe !!}
@@ -19,7 +19,10 @@
             @endif
 
             <label class="relative inline-flex items-center mt-2 mb-5 cursor-pointer">
-                <input type="checkbox" value="" class="sr-only peer">
+                <input type="checkbox"
+                    class="sr-only peer"
+                    wire:click="toggleCompleted"
+                    @if ($this->lesson->completed) checked @endif>
                 <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-indigo-300 dark:peer-focus:ring-indigo-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-indigo-600"></div>
                 <span class="ms-3 text-base font-medium text-gray-700 dark:text-gray-300">Marcar lección como completa</span>
             </label>
@@ -30,7 +33,7 @@
                     Anterior
                 </x-link-button>
                 @else
-                <x-link-button href="#" class="bg-gray-300 hover:bg-gray-300 focus:bg-gray-300 active:bg-gray-300 cursor-default" disabled>
+                <x-link-button href="#" class="!bg-gray-300 hover:bg-gray-300 focus:bg-gray-300 active:bg-gray-300 cursor-default" disabled>
                     Anterior
                 </x-link-button>
                 @endif
@@ -40,7 +43,7 @@
                     Siguiente
                 </x-link-button>
                 @else
-                <x-link-button href="#" class="bg-gray-300 hover:bg-gray-300 focus:bg-gray-300 active:bg-gray-300 cursor-default" disabled>
+                <x-link-button href="#" class="!bg-gray-300 hover:bg-gray-300 focus:bg-gray-300 active:bg-gray-300 cursor-default" disabled>
                     Siguiente
                 </x-link-button>
                 @endif
@@ -65,6 +68,11 @@
                         {{'@' . Str::slug($course->teacher->name, '')}}
                     </a>
                 </div>
+            </div>
+
+            <div class="mt-2 text-sm text-gray-600">{{$this->advance}}% completado</div>
+            <div class="w-full bg-gray-200 rounded-full h-1.5 mb-4 ">
+                <div class="bg-indigo-400 h-1.5 rounded-full transition-width ease-in-out duration-500" style="width: {{$this->advance}}%"></div>
             </div>
 
             <ul class="mt-4">

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\CourseController;
 use App\Http\Controllers\HomeController;
+use App\Livewire\CourseLearn;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -25,7 +26,7 @@ Route::post('courses/{course}/enroll', [CourseController::class, 'enroll'])
 
 
 
-Route::get('courses/{course}/learn', [CourseController::class, 'learn'])->name('courses.learn');
+Route::get('courses/{course}/learn', CourseLearn::class)->name('courses.learn');
 
 Route::middleware([
     'auth:sanctum',

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,9 +23,9 @@ Route::post('courses/{course}/enroll', [CourseController::class, 'enroll'])
     ->middleware('auth')
     ->name('courses.enroll');
 
-Route::get('courses-status/{course}', function ($course) {
-   return "Matriculado en el curso: {$course}";
-})->name('courses.status');
+
+
+Route::get('courses/{course}/learn', [CourseController::class, 'learn'])->name('courses.learn');
 
 Route::middleware([
     'auth:sanctum',

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,9 +24,7 @@ Route::post('courses/{course}/enroll', [CourseController::class, 'enroll'])
     ->middleware('auth')
     ->name('courses.enroll');
 
-
-
-Route::get('courses/{course}/learn', CourseLearn::class)->name('courses.learn');
+Route::get('courses/{course}/learn/{lesson?}', CourseLearn::class)->name('courses.learn');
 
 Route::middleware([
     'auth:sanctum',


### PR DESCRIPTION
En esta fusión implementamos la página del visor de cursos, donde el usuario encontrará el contenido de las distintas secciones y lecciones del curso.

Esta vista se compone de dos columnas, donde observamos:

Columna izquierda:
- Vídeo de la lección, con título y descripción.
- Botón conmutador para marcar o desmarcar la lección como completada.
- Botones para avanzar o retroceder entre las lecciones.

Columna derecha:
- Información resumida del curso, con información del autor
- Una barra de progreso sobre el curso en cuestión
- Listado de las secciones y lecciones del curso, con marcadores visuales que indican las lecciones completas del curso, así como la lección en la que nos encontramos.

Para implementar esta vista, se ha realizado un componente livewire de página completa, de modo que nos facilita realizar modificaciones dinámicas sobre la misma, como por ejemplo marcar una lección como completa, y que la barra de progreso o los marcadores de lección se actualicen sin necesidad de refrescar la página.

![dabaliu test_8000_courses_minus-fuga-velit-explicabo_learn_dolorum-amet-officiis-sed-necessitatibus-laborum-quia-vel(HD Laptop)](https://github.com/edumarrom/pdaw23/assets/73343241/a1a8b213-79b0-4099-8fbc-fa395a22e7cc)

