### PR TITLE
corregir hash bcrypt de la factoria de usuarios

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -24,7 +24,7 @@ class UserFactory extends Factory
             'name' => $this->faker->name(),
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'password' => '$2a$12$uXtwnfQRAYaFU5BxFJBkC.QZ/6tQUHj3QKzVuBKQSbHNFLJ1pQezi', // password
             'two_factor_secret' => null,
             'two_factor_recovery_codes' => null,
             'remember_token' => Str::random(10),


### PR DESCRIPTION
En esta fusión corrijo un error al colocar el hash bcrypt de la contraseña de los usuarios de prueba. Inicialmente era un hash bcrypt de 10 rounds y necesitaba que fuese de 12, que es el resultado por defecto al usar la función `brcypt`.

Podría haber usando directamente la función `bcrypt`, pero hacerlo incremenenta mucho el tiempo de ejecución de una migración limpia (`migrate:fresh --seed`), y creo que es un coste de ejecución innecesario.