### PR TITLE
Proteger rutas cursos

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -36,6 +36,8 @@ class CourseController extends Controller
      */
     public function show(Course $course)
     {
+        $this->authorize('published', $course);
+
         return view('courses.show', compact('course'));
     }
 

--- a/app/Livewire/CourseLearn.php
+++ b/app/Livewire/CourseLearn.php
@@ -4,10 +4,12 @@ namespace App\Livewire;
 
 use App\Models\Course;
 use App\Models\Lesson;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Component;
 
 class CourseLearn extends Component
 {
+    use AuthorizesRequests;
 
     public Course $course;
     public Lesson $lesson;
@@ -38,6 +40,8 @@ class CourseLearn extends Component
         $this->index = $course->lessons->pluck('id')->search($this->lesson->id);
         $this->previous = $course->lessons[$this->index - 1] ?? null;
         $this->next = $course->lessons[$this->index + 1] ?? null;
+
+        $this->authorize('enrolled', $course);
     }
 
     public function render()

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -24,4 +24,13 @@ class CoursePolicy
     {
         return $course->students->contains($user->id);
     }
+
+    /**
+     * Comprueba si un curso está publicado.
+     * @return bool
+     */
+    public function published(?User $user, Course $course)
+    {
+        return $course->status == 3;
+    }
 }

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -170,7 +170,7 @@
 
                         <div class="ml-2">
                             <p>Realizado por</p>
-                            <h3 class="text-3xl font-bold">
+                            <h3 class="text-xl font-bold">
                                 {{ $course->teacher->name }}
                             </h3>
                             <a class="text-sm text-teal-500 hover:text-teal-700"

--- a/resources/views/livewire/course-learn.blade.php
+++ b/resources/views/livewire/course-learn.blade.php
@@ -60,7 +60,7 @@
                 </figure>
                 <div class="ml-2">
                     <p>Realizado por</p>
-                    <h3 class="text-3xl font-bold">
+                    <h3 class="text-xl font-bold">
                         {{ $course->teacher->name }}
                     </h3>
                     <a class="text-sm text-teal-500 hover:text-teal-700"

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,9 @@ Route::post('courses/{course}/enroll', [CourseController::class, 'enroll'])
     ->middleware('auth')
     ->name('courses.enroll');
 
-Route::get('courses/{course}/learn/{lesson?}', CourseLearn::class)->name('courses.learn');
+Route::get('courses/{course}/learn/{lesson?}', CourseLearn::class)
+    ->middleware('auth')
+    ->name('courses.learn');
 
 Route::middleware([
     'auth:sanctum',


### PR DESCRIPTION
Con esta fusión implemento una protección sobre las rutas de los cursos para impedir el acceso al visor de cursos a los usuarios que no se encuentren matriculados al mismo.

Por otro lado también se han protegido las rutas de cursos que no se encuentren publicados, impidiendo acceder a ellos aunque se conozca su URL.