### PR TITLE
Menu edicion cursos

### DIFF
--- a/resources/views/teacher/courses/edit.blade.php
+++ b/resources/views/teacher/courses/edit.blade.php
@@ -1,7 +1,9 @@
 <x-app-layout>
-    <div class="container py-8">
+    <div class="container py-8 grid grid-cols-5">
 
-        <div class="card">
+        @include('teacher.courses.includes.aside')
+
+        <div class="card col-span-4">
 
             <div class="px6 py4 text-gray-700">
                 <h2 class="text-2xl font-bold">Información del curso</h2>

--- a/resources/views/teacher/courses/includes/aside.blade.php
+++ b/resources/views/teacher/courses/includes/aside.blade.php
@@ -1,0 +1,39 @@
+@php
+    $links = [
+        [
+            'name' => 'Información del curso',
+            'route' => route('teacher.courses.edit', $course),
+            'icon' => 'fa-solid fa-info-circle',
+            'active' => request()->routeIs('teacher.courses.edit'),
+        ],
+        [
+            'name' => 'Contenido del curso',
+            'route' => '',
+            'icon' => 'fa-solid fa-book',
+            'active' => request()->routeIs('teacher.courses.edit.content'),
+        ],
+        [
+            'name' => 'Metas y requisitos',
+            'route' => '',
+            'icon' => 'fa-solid fa-list-check',
+            'active' => request()->routeIs('teacher.courses.edit.goals'),
+        ],
+    ];
+@endphp
+
+<aside class="text-gray-800">
+    <p class="text-2xl font-medium text-gray-900 mb-4">Menú de edición</p>
+
+    <ul class="text-lg">
+
+        @foreach ($links as $link)
+                <li>
+                    <a  href="{{ $link['route'] }}"
+                        class="flex items-center p-2 text-gray-900 rounded-lg hover:bg-gray-200 hover:cursor-pointer
+                        {{ $link['active'] ? 'text-indigo-500' : '' }}">
+                        <span class="">{{ $link['name'] }}</span>
+                    </a>
+                </li>
+        @endforeach
+    </ul>
+</aside>


### PR DESCRIPTION
Con esta fusión implemento un menú lateral para que el profesor pueda acceder a los distintos apartados de edición del curso.

Este menú lo he definido a partir del menú aside que realicé para el cpanel de administración. Sus enlaces se definen en un array, que podremos fácilmente editar, y para mejorar la legibilidad de las vistas de edición del curso se incluye desde una plantilla blade aparte.