### PR TITLE
Editar datos de plataforma

### DIFF
--- a/app/Livewire/Teacher/CoursesLesson.php
+++ b/app/Livewire/Teacher/CoursesLesson.php
@@ -20,12 +20,6 @@ class CoursesLesson extends Component
     public $platform_id = 1;
     public $path;
 
-    /* @todo: Crear un nuevo campo en la tabla platforms con la regex */
-    public $platformPatterns = [
-        1 => '/^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?$/',
-        2 => '/^(http|https)?:\/\/(www\.|player\.)?vimeo\.com\/(?:channels\/(?:\w+\/)?|groups\/([^\/]*)\/videos\/|video\/|)(\d+)(?:|\/\?)$/mi',
-    ];
-
     protected $rules = [
         'lesson.title' => ['required', 'string', 'max:80'],
         'lesson.slug' => ['required', 'max:255', 'unique:lessons,slug'],
@@ -54,7 +48,8 @@ class CoursesLesson extends Component
             'title' => $this->rules['lesson.title'],
             'slug' => $this->rules['lesson.slug'],
             'platform_id' => $this->rules['lesson.platform_id'],
-            'path' => ['required', 'url', $this->platformPatterns[$this->platform_id]],
+            //'path' => ['required', 'url', 'regex:' . $this->platformPatterns[$this->platform_id]],
+            'path' => ['required', 'url', 'regex:' . Platform::find($this->platform_id)->pattern],
             'description' => $this->rules['lesson.description.description'],
         ]);
 
@@ -100,7 +95,8 @@ class CoursesLesson extends Component
     {
         $lessonTitle = $this->lesson->title;
 
-        $this->rules['lesson.path'] = ['required', 'url', $this->platformPatterns[$this->platform_id]];
+        //$this->rules['lesson.path'] = ['required', 'url', 'regex:' . $this->platformPatterns[$this->platform_id]];
+        $this->rules['lesson.path'] = ['required', 'url', 'regex:' . $this->lesson->platform->pattern];
         $this->rules['lesson.slug'] = ['required', 'unique:lessons,slug,' . $this->lesson->id];
 
         $this->validate();

--- a/app/Observers/LessonObserver.php
+++ b/app/Observers/LessonObserver.php
@@ -6,25 +6,6 @@ use App\Models\Lesson;
 
 class LessonObserver
 {
-    public $platformData = [
-        1 => [
-            'pattern' => '/^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?$/',
-            'match' => 5,
-            'iframe' => [
-                '<iframe width="560" height="315" src="https://www.youtube.com/embed/',
-                '" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>',
-            ],
-        ],
-        2 => [
-            'pattern' => '/^(http|https)?:\/\/(www\.|player\.)?vimeo\.com\/(?:channels\/(?:\w+\/)?|groups\/([^\/]*)\/videos\/|video\/|)(\d+)(?:|\/\?)$/mi',
-            'match' => 4,
-            'iframe' => [
-                '<iframe src="https://player.vimeo.com/video/',
-                '" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>',
-            ],
-        ],
-    ];
-
     public function creating(Lesson $lesson)
     {
         $path = $lesson->path;
@@ -38,22 +19,24 @@ class LessonObserver
         $path = $lesson->path;
         $platformId = $lesson->platform_id;
 
-        $lesson->iframe = $this->getVideoIframe($path, $platformId);
+        $lesson->iframe = $this->getVideoIframe($lesson);
     }
 
-    private function getVideoId($path, $platformId)
+    private function getVideoId(Lesson $lesson)
     {
-        $pattern = $this->platformData[$platformId]['pattern'];
+        $pattern = $lesson->platform->pattern;
+        $path = $lesson->path;
+
         preg_match($pattern, $path, $matches);
-        $match = $this->platformData[$platformId]['match'];
+        $match = $lesson->platform->match;
 
         return $matches[$match];
     }
 
-    private function getVideoIframe($path, $platformId)
+    private function getVideoIframe(Lesson $lesson)
     {
-        $iframe = $this->platformData[$platformId]['iframe'];
-        $videoId = $this->getVideoId($path, $platformId);
+        $iframe = json_decode($lesson->platform->iframe);
+        $videoId = $this->getVideoId($lesson);
 
         return $iframe[0] . $videoId . $iframe[1];
     }

--- a/database/migrations/2023_11_16_195054_create_platforms_table.php
+++ b/database/migrations/2023_11_16_195054_create_platforms_table.php
@@ -14,6 +14,9 @@ return new class extends Migration
         Schema::create('platforms', function (Blueprint $table) {
             $table->id();
             $table->string('name');
+            $table->string('pattern');
+            $table->tinyInteger('match');
+            $table->json('iframe');
             $table->timestamps();
         });
     }

--- a/database/seeders/PlatformSeeder.php
+++ b/database/seeders/PlatformSeeder.php
@@ -15,10 +15,22 @@ class PlatformSeeder extends Seeder
     {
         Platform::create([
             'name' => 'Youtube',
+            'pattern' => '/^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?$/',
+            'match' => 5,
+            'iframe' => json_encode([
+                '<iframe width="560" height="315" src="https://www.youtube.com/embed/',
+                '" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>',
+            ]),
         ]);
 
         Platform::create([
             'name' => 'Vimeo',
+            'pattern' => '/^(http|https)?:\/\/(www\.|player\.)?vimeo\.com\/(?:channels\/(?:\w+\/)?|groups\/([^\/]*)\/videos\/|video\/|)(\d+)(?:|\/\?)$/mi',
+            'match' => 4,
+            'iframe' => json_encode([
+                '<iframe src="https://player.vimeo.com/video/',
+                '" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>',
+            ]),
         ]);
     }
 }


### PR DESCRIPTION
Con esta fusión hemos incluido nuevos campos en la tabla de plataformas:

- Patrón regex con la que procesar el enlace de un vídeo de la plataforma.
- Posición donde se ubica el ID del video al segmentar la URL con la regex
- Array codificado en JSON con el elemento iframe dividido entre la parte previa al ID y la parte posterior.

He modificado el seeder de plataforma de acuerdo con estos nuevos campos, y he refactorizado el código del compomente Livewire de lecciones y el observador de lecciones para hacer uso de las nuevas propiedades.

#### Nota:
Aunque esta inclusión la he realizado modificando la migración existente de creación de la tabla de plataformas y volviendo a hacer una migración limpia, hay casos en los que esto no se podría, por ejemplo si la aplicación se encuentra en producción.

Para esos casos se puede realizar la actualizción de la tabla creando una nueva migración que inserte los nuevos campos y migrar sólo esa nueva inclusión.