### PR TITLE
Recurso de lecciones

### DIFF
--- a/app/Livewire/Teacher/CoursesLesson.php
+++ b/app/Livewire/Teacher/CoursesLesson.php
@@ -82,6 +82,14 @@ class CoursesLesson extends Component
             'description' => $this->description,
         ]);
 
+        if ($this->resource) {
+            $fileName = time() . '_' . $this->resource->getClientOriginalName();
+
+            $lesson->resource()->create([
+                    'path' => $this->resource->storeAs('resources', $fileName),
+                ]);
+        }
+
         $this->reset([
             'title',
             'slug',

--- a/app/Livewire/Teacher/CoursesLesson.php
+++ b/app/Livewire/Teacher/CoursesLesson.php
@@ -7,13 +7,17 @@ use App\Models\Platform;
 use App\Models\Section;
 use Illuminate\Support\Str;
 use Livewire\Component;
+use Livewire\WithFileUploads;
 
 class CoursesLesson extends Component
 {
+    use WithFileUploads;
+
     public $section;
     public $lesson;
     public $platforms;
     public $description;
+    public $resource;
 
     public $title;
     public $slug;
@@ -26,6 +30,7 @@ class CoursesLesson extends Component
         'lesson.platform_id' => ['required', 'exists:platforms,id'],
         'lesson.path' => ['required', 'url', 'max:255'],
         'lesson.description.description' => ['required', 'string', 'max:500'],
+        'resource' => ['nullable'],
     ];
 
     public function mount(Section $section)
@@ -89,6 +94,7 @@ class CoursesLesson extends Component
         $this->resetValidation();
         $this->lesson = Lesson::find($id);
         $this->description = $this->lesson->description->description;
+        // $this->resource = $this->lesson->resource;
     }
 
     public function updateLesson()
@@ -102,6 +108,23 @@ class CoursesLesson extends Component
 
         $this->lesson->description->save();
         $this->lesson->save();
+
+        if ($this->resource) {
+            $fileName = time() . '_' . $this->resource->getClientOriginalName();
+
+            // Si la lección tiene un recurso, se actualiza, en caso contrario se crea
+            if ($this->lesson->resource) {
+                // @todo: Eliminar el recurso anterior
+
+                $this->lesson->resource->update([
+                    'path' => $this->resource->storeAs('resources', $fileName),
+                ]);
+            } else {
+                $this->lesson->resource()->create([
+                    'path' => $this->resource->storeAs('resources', $fileName),
+                ]);
+            }
+        }
 
         $this->lesson = new Lesson();
         $this->section = Section::find($this->section->id);

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -9,7 +9,6 @@ class Resource extends Model
 {
     use HasFactory;
 
-    // protected $fillable = ['path', 'resourceable_id', 'resourceable_type'];
     protected $fillable = ['path'];
 
     public function resourceable()

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -9,6 +9,9 @@ class Resource extends Model
 {
     use HasFactory;
 
+    // protected $fillable = ['path', 'resourceable_id', 'resourceable_type'];
+    protected $fillable = ['path'];
+
     public function resourceable()
     {
         return $this->morphTo();

--- a/app/Observers/LessonObserver.php
+++ b/app/Observers/LessonObserver.php
@@ -3,6 +3,7 @@
 namespace App\Observers;
 
 use App\Models\Lesson;
+use Illuminate\Support\Facades\Storage;
 
 class LessonObserver
 {
@@ -14,6 +15,14 @@ class LessonObserver
     public function updating(Lesson $lesson)
     {
         $lesson->iframe = $this->getVideoIframe($lesson);
+    }
+
+    public function deleting(Lesson $lesson)
+    {
+        if ($lesson->resource) {
+            Storage::delete($lesson->resource->path);
+            $lesson->resource->delete();
+        }
     }
 
     private function getVideoId(Lesson $lesson)

--- a/app/Observers/LessonObserver.php
+++ b/app/Observers/LessonObserver.php
@@ -8,17 +8,11 @@ class LessonObserver
 {
     public function creating(Lesson $lesson)
     {
-        $path = $lesson->path;
-        $platformId = $lesson->platform_id;
-
-        $lesson->iframe = $this->getVideoIframe($path, $platformId);
+        $lesson->iframe = $this->getVideoIframe($lesson);
     }
 
     public function updating(Lesson $lesson)
     {
-        $path = $lesson->path;
-        $platformId = $lesson->platform_id;
-
         $lesson->iframe = $this->getVideoIframe($lesson);
     }
 

--- a/app/Observers/SectionObserver.php
+++ b/app/Observers/SectionObserver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Section;
+use Illuminate\Support\Facades\Storage;
+
+class SectionObserver
+{
+    public function deleting(Section $section)
+    {
+        $section->lessons->each(function ($lesson) {
+            if ($lesson->resource) {
+                Storage::delete($lesson->resource->path);
+                $lesson->resource->delete();
+            }
+        });
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -26,6 +26,7 @@ class EventServiceProvider extends ServiceProvider
     public function boot(): void
     {
         \App\Models\Lesson::observe(\App\Observers\LessonObserver::class);
+        \App\Models\Section::observe(\App\Observers\SectionObserver::class);
     }
 
     /**

--- a/resources/views/livewire/teacher/courses-lesson.blade.php
+++ b/resources/views/livewire/teacher/courses-lesson.blade.php
@@ -56,7 +56,7 @@
                             <x-input-error for="lesson.path" class="mt-2" />
                         </div>
 
-                        <div class="mb-4">
+                        <div class="mb-2">
                             <x-label for="description" class="mb-2"  value="Descripción" />
                             <x-textarea id="description"
                                         name="description"
@@ -65,6 +65,20 @@
                                         placeholder="Escribe una descripción para esta lección"
                                         wire:model.live="lesson.description.description"></x-textarea>
                             <x-input-error for="lesson.description.description" class="mt-2" />
+                        </div>
+
+                        <div class="mb-4">
+                            <x-label for="resource" class="mb-1" value="Recurso" />
+                            <x-input id="resource"
+                                    name="resource"
+                                    type="file"
+                                    class="block w-full bg-white px-3 py-2 border border-gray-300 text-sm shadow-sm rounded cursor-pointer"
+                                    wire:model.live="resource" />
+                            <x-input-error for="resource" class="mt-2" />
+
+                            <div class="mt-2" wire:loading wire:target="resource">
+                                <span>Cargando...</span>
+                            </div>
                         </div>
 
                         <div class="flex justify-end">

--- a/resources/views/livewire/teacher/courses-lesson.blade.php
+++ b/resources/views/livewire/teacher/courses-lesson.blade.php
@@ -249,7 +249,7 @@
                         <x-input-error for="path" class="mt-2" />
                     </div>
 
-                    <div class="mb-4">
+                    <div class="mb-2">
                         <x-label for="description" class="mb-2"  value="Descripción" />
                         <x-textarea id="description"
                                     name="description"
@@ -258,6 +258,19 @@
                                     placeholder="Escribe una descripción para esta lección"
                                     wire:model.live="description"></x-textarea>
                         <x-input-error for="description" class="mt-2" />
+                    </div>
+
+                    <div class="mb-4">
+
+                        <x-label for="resource" class="mb-1" value="Recurso" />
+                        <div class="px-3 py-2 border border-gray-300 text-sm rounded">
+                            <x-input id="resource"
+                                     name="resource"
+                                     type="file"
+                                     class="block w-full py-2 shadow-none"
+                                     wire:model.live="resource" />
+                            <x-input-error for="resource" class="mt-2" />
+                        </div>
                     </div>
 
                     <div class="flex justify-between">

--- a/resources/views/livewire/teacher/courses-lesson.blade.php
+++ b/resources/views/livewire/teacher/courses-lesson.blade.php
@@ -68,13 +68,37 @@
                         </div>
 
                         <div class="mb-4">
+
                             <x-label for="resource" class="mb-1" value="Recurso" />
-                            <x-input id="resource"
-                                    name="resource"
-                                    type="file"
-                                    class="block w-full bg-white px-3 py-2 border border-gray-300 text-sm shadow-sm rounded cursor-pointer"
-                                    wire:model.live="resource" />
-                            <x-input-error for="resource" class="mt-2" />
+                            <div class="px-3 py-2 border border-gray-300 text-sm rounded">
+
+                                @if ($item->resource)
+                                <div class="flex justify-between">
+
+                                    <div wire:click="downloadResource({{ $item->id }})">
+                                        <span>Recurso actual:</span>
+                                        <span class="hover:text-indigo-500 ml-1 hover:cursor-pointer">
+                                            <i class="fa-solid fa-download text-lg mr-1"></i>
+                                            <span>{{ Str::afterLast($item->resource->path, '/') }}</span>
+                                        </span>
+                                    </div>
+
+                                    <x-secondary-button type="button"
+                                            class="hover:bg-rose-600 hover:text-white"
+                                            wire:click="destroyResource({{ $item->id }})">
+                                        <i class="fa-solid fa-trash"></i>
+                                    </x-secondary-button>
+
+                                </div>
+                                @endif
+
+                                <x-input id="resource"
+                                         name="resource"
+                                         type="file"
+                                         class="block w-full py-2 shadow-none"
+                                         wire:model.live="resource" />
+                                <x-input-error for="resource" class="mt-2" />
+                            </div>
 
                             <div class="mt-2" wire:loading wire:target="resource">
                                 <span>Cargando...</span>
@@ -126,10 +150,19 @@
                         <p class="text-sm">
                             Enlace:
                             <a href="{{ $item->path }}" target="_blank"
-                                class="text-indigo-500">
+                                    class="text-indigo-500">
                                 {{ $item->path }}
                             </a>
                         </p>
+                        @if ($item->resource)
+                        <div class="text-sm" wire:click="downloadResource({{ $item->id }})">
+                            <span>Recurso:</span>
+                            <span class="hover:text-indigo-500 hover:cursor-pointer ml-1">
+                                <i class="fa-solid fa-download text-lg mr-1"></i>
+                                <span>{{ Str::afterLast($item->resource->path, '/') }}</span>
+                            </span>
+                        </div>
+                        @endif
                     </div>
 
                     <div class="flex justify-end">


### PR DESCRIPTION
En esta fusión implementamos la capacidad de poder asignar un recurso a una lección, es decir, material descargable por el usuario. Una lección podrá tener sólo un recurso, pero eso no impide que se puedan subir varios ficheros en un solo comprimido.

Para ello, se ha incluido un nuevo campo en los formularios de creación y edición que permiten al profesor subir un fichero. Actualmente no existe ninguna restricción con respecto al tamaño máximo de archivo o su extensión, pero es algo que reconsiderar más adelante.

Si una lección tiene asignado un recurso, esta información estará visible en la ficha de la lección, y también en el formulario de edición, permitiendo al profesor descargar dicho recurso si lo necesita.

Actualizar un recurso sustituirá al anterior, y desde el formulario de edición también tiene la posibilidad eliminar el recurso actual.

Desde el punto de vista técnico he tenido en cuenta que los recursos sustituidos deben borrarse de la aplicación para no ocupar espacio innecesrio. Del mismo modo si se borra una lección, he definido el método `deleting()` en el observador de lecciones para que se encargue de manejar el borrado, tanto del fichero del disco como del registro del recurso en la base de datos.

Igualmente, en el caso en que se borre una sección entera, ahora hay un observador para secciones, el cual se encargará de eliminar los recursos de todas las lecciones.

![dabaliu test_8000_teacher_courses_mi-primer-curso_edit_content(HD Laptop) (4)](https://github.com/edumarrom/pdaw23/assets/73343241/e4419e4a-b65a-4d31-90ec-fa12ade50e14)

![dabaliu test_8000_teacher_courses_mi-primer-curso_edit_content(HD Laptop) (5)](https://github.com/edumarrom/pdaw23/assets/73343241/67316849-c2c2-4122-9e16-1274d1a3ec3a)
