### PR TITLE
Editar metas y requisitos

### DIFF
--- a/app/Http/Controllers/Teacher/CourseController.php
+++ b/app/Http/Controllers/Teacher/CourseController.php
@@ -158,4 +158,9 @@ class CourseController extends Controller
     {
         return $course;
     }
+
+    public function goals(Course $course)
+    {
+        return view('teacher.courses.goals', compact('course'));
+    }
 }

--- a/app/Livewire/Teacher/CoursesGoals.php
+++ b/app/Livewire/Teacher/CoursesGoals.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Livewire\Teacher;
+
+use App\Models\Course;
+use App\Models\Goal;
+use Livewire\Component;
+
+class CoursesGoals extends Component
+{
+    public $course;
+    public $goal;
+
+    public $name;
+
+    protected $rules = [
+        'goal.name' => 'required'
+    ];
+
+    public function mount(Course $course)
+    {
+        $this->course = $course;
+        $this->goal = new Goal();
+    }
+
+    public function render()
+    {
+        return view('livewire.teacher.courses-goals');
+    }
+
+    public function store()
+    {
+        $this->validate([
+            'name' => $this->rules['goal.name'],
+        ]);
+
+        $this->course->goals()->create([
+            'name' => $this->name,
+        ]);
+
+        $this->reset('name');
+
+        $this->course = Course::find($this->course->id);
+    }
+
+    public function edit(Goal $goal)
+    {
+        $this->goal = $goal;
+    }
+
+    public function update()
+    {
+        $this->validate();
+
+        $this->goal->save();
+
+        $this->goal = new Goal();
+
+        $this->course = Course::find($this->course->id);
+    }
+
+    public function destroy(Goal $goal)
+    {
+        $goal->delete();
+
+        $this->course = Course::find($this->course->id);
+    }
+
+    public function cancel()
+    {
+        $this->goal = new Goal();
+    }
+}

--- a/app/Livewire/Teacher/CoursesGoals.php
+++ b/app/Livewire/Teacher/CoursesGoals.php
@@ -34,13 +34,20 @@ class CoursesGoals extends Component
             'name' => $this->rules['goal.name'],
         ]);
 
-        $this->course->goals()->create([
+        $goal = $this->course->goals()->create([
             'name' => $this->name,
         ]);
 
         $this->reset('name');
 
         $this->course = Course::find($this->course->id);
+
+        $this->dispatch('swal', [
+            'icon' => 'success',
+            'title' => '¡Hecho!',
+            'text' => "Meta '$goal->name' creada satisfactoriamente.",
+            'confirmButtonColor' => '#4338CA',
+        ]);
     }
 
     public function edit(Goal $goal)
@@ -50,6 +57,8 @@ class CoursesGoals extends Component
 
     public function update()
     {
+        $name = $this->goal->name;
+
         $this->validate();
 
         $this->goal->save();
@@ -57,13 +66,29 @@ class CoursesGoals extends Component
         $this->goal = new Goal();
 
         $this->course = Course::find($this->course->id);
+
+        $this->dispatch('swal', [
+            'icon' => 'success',
+            'title' => '¡Hecho!',
+            'text' => "Meta '$name' editada satisfactoriamente.",
+            'confirmButtonColor' => '#4338CA',
+        ]);
     }
 
     public function destroy(Goal $goal)
     {
+        $name = $goal->name;
+
         $goal->delete();
 
         $this->course = Course::find($this->course->id);
+
+        $this->dispatch('swal', [
+            'icon' => 'success',
+            'title' => '¡Hecho!',
+            'text' => "Meta '$name' borrada satisfactoriamente.",
+            'confirmButtonColor' => '#4338CA',
+        ]);
     }
 
     public function cancel()

--- a/app/Livewire/Teacher/CoursesRequirements.php
+++ b/app/Livewire/Teacher/CoursesRequirements.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Livewire\Teacher;
+
+use App\Models\Course;
+use App\Models\Requirement;
+use Livewire\Component;
+
+class CoursesRequirements extends Component
+{
+    public $course;
+    public $requirement;
+
+    public $name;
+
+    protected $rules = [
+        'requirement.name' => 'required'
+    ];
+
+    public function mount(Course $course)
+    {
+        $this->course = $course;
+        $this->requirement = new Requirement();
+    }
+
+    public function render()
+    {
+        return view('livewire.teacher.courses-requirements');
+    }
+
+    public function store()
+    {
+        $this->validate([
+            'name' => $this->rules['requirement.name'],
+        ]);
+
+        $this->course->requirements()->create([
+            'name' => $this->name,
+        ]);
+
+        $this->reset('name');
+
+        $this->course = Course::find($this->course->id);
+    }
+
+    public function edit(Requirement $requirement)
+    {
+        $this->requirement = $requirement;
+    }
+
+    public function update()
+    {
+        $this->validate();
+
+        $this->requirement->save();
+
+        $this->requirement = new Requirement();
+
+        $this->course = Course::find($this->course->id);
+    }
+
+    public function destroy(Requirement $requirement)
+    {
+        $requirement->delete();
+
+        $this->course = Course::find($this->course->id);
+    }
+
+    public function cancel()
+    {
+        $this->requirement = new Requirement();
+    }
+}

--- a/app/Livewire/Teacher/CoursesRequirements.php
+++ b/app/Livewire/Teacher/CoursesRequirements.php
@@ -34,13 +34,20 @@ class CoursesRequirements extends Component
             'name' => $this->rules['requirement.name'],
         ]);
 
-        $this->course->requirements()->create([
+        $requirement = $this->course->requirements()->create([
             'name' => $this->name,
         ]);
 
         $this->reset('name');
 
         $this->course = Course::find($this->course->id);
+
+        $this->dispatch('swal', [
+            'icon' => 'success',
+            'title' => '¡Hecho!',
+            'text' => "Requisito '$requirement->name' creado satisfactoriamente.",
+            'confirmButtonColor' => '#4338CA',
+        ]);
     }
 
     public function edit(Requirement $requirement)
@@ -50,6 +57,8 @@ class CoursesRequirements extends Component
 
     public function update()
     {
+        $name = $this->requirement->name;
+
         $this->validate();
 
         $this->requirement->save();
@@ -57,13 +66,29 @@ class CoursesRequirements extends Component
         $this->requirement = new Requirement();
 
         $this->course = Course::find($this->course->id);
+
+        $this->dispatch('swal', [
+            'icon' => 'success',
+            'title' => '¡Hecho!',
+            'text' => "Requisito '$name' editado satisfactoriamente.",
+            'confirmButtonColor' => '#4338CA',
+        ]);
     }
 
     public function destroy(Requirement $requirement)
     {
+        $name = $requirement->name;
+
         $requirement->delete();
 
         $this->course = Course::find($this->course->id);
+
+        $this->dispatch('swal', [
+            'icon' => 'success',
+            'title' => '¡Hecho!',
+            'text' => "Requisito '$name' borrado satisfactoriamente.",
+            'confirmButtonColor' => '#4338CA',
+        ]);
     }
 
     public function cancel()

--- a/app/Models/Goal.php
+++ b/app/Models/Goal.php
@@ -9,6 +9,8 @@ class Goal extends Model
 {
     use HasFactory;
 
+    protected $fillable = ['name'];
+
     public function course()
     {
         return $this->belongsTo(Course::class);

--- a/app/Models/Requirement.php
+++ b/app/Models/Requirement.php
@@ -9,6 +9,8 @@ class Requirement extends Model
 {
     use HasFactory;
 
+    protected $fillable = ['name'];
+
     public function course()
     {
         return $this->belongsTo(Course::class);

--- a/resources/views/livewire/teacher/courses-goals.blade.php
+++ b/resources/views/livewire/teacher/courses-goals.blade.php
@@ -49,8 +49,8 @@
                                     <i class="fa-solid fa-pen mr-1"></i>Editar
                                 </span>
                                 <span class="inline-block cursor-pointer text-rose-500 hover:text-rose-700"
-                                    wire:click="destroy({{ $item }})"
-                                    {{-- onclick="deleteGoal({{ $item->id }})" --}}>
+                                    {{-- wire:click="destroy({{ $item }})" --}}
+                                    onclick="destroyGoal({{ $item }})">
                                     <i class="fa-solid fa-trash mr-1"></i>Eliminar
                                 </span>
                             </div>
@@ -107,4 +107,37 @@
             </div>
         </article>
     </div>
+
+    @push('scripts')
+        <script>
+            window.addEventListener('swal', event => {
+                const detail = event.detail[0];
+                Swal.fire({
+                    icon: detail.icon,
+                    title: detail.title,
+                    text: detail.text,
+                    confirmButtonColor: detail.confirmButtonColor,
+                })
+            })
+        </script>
+
+        <script>
+            function destroyGoal(goal) {
+                Swal.fire({
+                    icon: 'warning',
+                    title: '¿Estás seguro?',
+                    text: "Esta acción es irreversible",
+                    showCancelButton: true,
+                    confirmButtonText: 'Confirmar',
+                    confirmButtonColor: '#EF4444',
+                    cancelButtonText: 'Cancelar',
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        @this.call('destroy', goal);
+                    }
+                })
+            }
+        </script>
+    @endpush
+
 </div>

--- a/resources/views/livewire/teacher/courses-goals.blade.php
+++ b/resources/views/livewire/teacher/courses-goals.blade.php
@@ -1,0 +1,111 @@
+<div>
+    <h2 class="text-2xl font-bold">
+        <i class="fa-solid fa-graduation-cap mr-1"></i>
+        Metas del curso
+    </h2>
+    <hr class="mt-2 mb-6">
+
+    @if ($course->goals->count())
+
+        {{-- ¿Por qué la ordenación no funciona? --}}
+        @foreach ($course->goals->sortBy(['created_at', 'id desc']) as $item)
+
+            <article class="card mb-6 border border-gray-100 shadow-md">
+
+                <div class="px-6 py4">
+
+                    <!-- Formulario de edición -->
+                    @if ($goal->id == $item->id)
+                        <form wire:submit.prevent="update" class="flex">
+                            <x-input id="name"
+                                    name="name"
+                                    type="text"
+                                    class="block w-full"
+                                    placeholder="Escribe un nombre para esta meta"
+                                    wire:model.live="goal.name" />
+                            <x-input-error for="goal.name" class="ml-2" />
+
+                            <x-secondary-button type="button" class="hover:bg-rose-600 hover:text-white ml-1"
+                                    wire:click="cancel" title="Cancelar">
+                                <i class="fa-solid fa-xmark"></i>
+                            </x-secondary-button>
+                            <x-secondary-button type="submit" class="hover:bg-indigo-500 hover:text-white ml-1"
+                                    title="Guardar">
+                                <i class="fa-solid fa-check"></i>
+                            </x-secondary-button>
+                        </form>
+                    @else
+
+                        <header class="flex justify-between items-center">
+                            <h3 class="text-lg select-none hover:text-indigo-500 hover:cursor-pointer">
+                                <i class="fa-solid fa-caret-right text-lg mr-2 transition-all"></i>
+                                <span class="font-semibold">Meta:</span>
+                                {{$item->name}}
+                            </h3>
+
+                            <div class="flex flex-col text-sm">
+                                <span class="inline-block cursor-pointer text-gray-500 hover:text-gray-700"
+                                    wire:click="edit({{ $item }})">
+                                    <i class="fa-solid fa-pen mr-1"></i>Editar
+                                </span>
+                                <span class="inline-block cursor-pointer text-rose-500 hover:text-rose-700"
+                                    wire:click="destroy({{ $item }})"
+                                    {{-- onclick="deleteGoal({{ $item->id }})" --}}>
+                                    <i class="fa-solid fa-trash mr-1"></i>Eliminar
+                                </span>
+                            </div>
+                        </header>
+
+                    @endif
+
+                </div>
+
+            </article>
+
+        @endforeach
+    @else
+
+        <div class="flex items-center justify-center p-4">
+            <div class="flex flex-col items-center">
+                <img class="w-64 h-auto mb-4" src="{{ asset('img/tumbleweed.png') }}" alt="">
+                {{-- Source: https://www.creativefabrica.com/product/cactus-tumbleweed-2/ref/154380/ --}}
+                <h3 class="text-lg font-bold text-gray-600">Esto está muy tranquilo, demasiado...</h3>
+            </div>
+        </div>
+
+    @endif
+
+    <div x-data="{open: false}">
+        <x-button type="button" color="indigo" x-on:click="open =!open">
+            <i class="fa-solid fa-plus mr-1"></i>
+            <span>Nueva meta</span>
+        </x-button>
+
+        <article class="card my-6 border border-gray-100 shadow-md"
+                 x-show="open" x-collapse>
+            <div class="px-6 py4 text-gray-700">
+                <h3 class="text-xl font-bold">Nueva meta</h3>
+                <hr class="mt-2 mb-6">
+
+                <form wire:submit.prevent="store" class="flex">
+                    <x-input id="name"
+                            name="name"
+                            type="text"
+                            class="block w-full"
+                            placeholder="Escribe un nombre para esta meta"
+                            wire:model.live="name" />
+                    <x-input-error for="name" class="ml-2" />
+
+                    <x-secondary-button class="hover:bg-rose-600 hover:text-white ml-1"
+                            x-on:click="open = false" title="Cancelar">
+                        <i class="fa-solid fa-xmark"></i>
+                    </x-secondary-button>
+                    <x-secondary-button type="submit" class="hover:bg-indigo-500 hover:text-white ml-1"
+                            title="Guardar">
+                        <i class="fa-solid fa-save"></i>
+                    </x-secondary-button>
+                </form>
+            </div>
+        </article>
+    </div>
+</div>

--- a/resources/views/livewire/teacher/courses-requirements.blade.php
+++ b/resources/views/livewire/teacher/courses-requirements.blade.php
@@ -49,8 +49,7 @@
                                     <i class="fa-solid fa-pen mr-1"></i>Editar
                                 </span>
                                 <span class="inline-block cursor-pointer text-rose-500 hover:text-rose-700"
-                                    wire:click="destroy({{ $item }})"
-                                    {{-- onclick="deleteRequirement({{ $item->id }})" --}}>
+                                    onclick="destroyRequirement({{ $item }})">
                                     <i class="fa-solid fa-trash mr-1"></i>Eliminar
                                 </span>
                             </div>
@@ -107,4 +106,36 @@
             </div>
         </article>
     </div>
+
+    @push('scripts')
+        <script>
+            window.addEventListener('swal', event => {
+                const detail = event.detail[0];
+                Swal.fire({
+                    icon: detail.icon,
+                    title: detail.title,
+                    text: detail.text,
+                    confirmButtonColor: detail.confirmButtonColor,
+                })
+            })
+        </script>
+
+        <script>
+            function destroyRequirement(requirement) {
+                Swal.fire({
+                    icon: 'warning',
+                    title: '¿Estás seguro?',
+                    text: "Esta acción es irreversible",
+                    showCancelButton: true,
+                    confirmButtonText: 'Confirmar',
+                    confirmButtonColor: '#EF4444',
+                    cancelButtonText: 'Cancelar',
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        @this.call('destroy', requirement);
+                    }
+                })
+            }
+        </script>
+    @endpush
 </div>

--- a/resources/views/livewire/teacher/courses-requirements.blade.php
+++ b/resources/views/livewire/teacher/courses-requirements.blade.php
@@ -1,29 +1,29 @@
 <div>
     <h2 class="text-2xl font-bold">
-        <i class="fa-solid fa-graduation-cap mr-1"></i>
-        Metas del curso
+        <i class="fa-solid fa-list-check mr-1"></i>
+        Requisitos del curso
     </h2>
     <hr class="mt-2 mb-6">
 
-    @if ($course->goals->count())
+    @if ($course->requirements->count())
 
         {{-- ¿Por qué la ordenación no funciona? --}}
-        @foreach ($course->goals->sortBy(['created_at', 'id desc']) as $item)
+        @foreach ($course->requirements->sortBy(['created_at', 'id desc']) as $item)
 
             <article class="card mb-6 border border-gray-100 shadow-md">
 
                 <div class="px-6 py4">
 
                     <!-- Formulario de edición -->
-                    @if ($goal->id == $item->id)
+                    @if ($requirement->id == $item->id)
                         <form wire:submit.prevent="update" class="flex">
                             <x-input id="name"
                                     name="name"
                                     type="text"
                                     class="block w-full"
-                                    placeholder="Escribe un nombre para esta meta"
-                                    wire:model.live="goal.name" />
-                            <x-input-error for="goal.name" class="ml-2" />
+                                    placeholder="Escribe un nombre para este requisito"
+                                    wire:model.live="requirement.name" />
+                            <x-input-error for="requirement.name" class="ml-2" />
 
                             <x-secondary-button type="button" class="hover:bg-rose-600 hover:text-white ml-1"
                                     wire:click="cancel" title="Cancelar">
@@ -39,7 +39,7 @@
                         <header class="flex justify-between items-center">
                             <h3 class="text-lg select-none">
                                 <i class="fa-solid fa-check text-lg mr-2 transition-all"></i>
-                                <span class="font-semibold">Meta:</span>
+                                <span class="font-semibold">Requisito:</span>
                                 {{$item->name}}
                             </h3>
 
@@ -50,7 +50,7 @@
                                 </span>
                                 <span class="inline-block cursor-pointer text-rose-500 hover:text-rose-700"
                                     wire:click="destroy({{ $item }})"
-                                    {{-- onclick="deleteGoal({{ $item->id }})" --}}>
+                                    {{-- onclick="deleteRequirement({{ $item->id }})" --}}>
                                     <i class="fa-solid fa-trash mr-1"></i>Eliminar
                                 </span>
                             </div>
@@ -67,8 +67,8 @@
 
         <div class="flex items-center justify-center p-4">
             <div class="flex flex-col items-center">
-                <i class="fa-solid fa-graduation-cap text-8xl text-gray-200 mb-6"></i>
-                <h3 class="text-lg font-bold text-gray-500">No hay metas definidas para este curso</h3>
+                <i class="fa-solid fa-list-check text-8xl text-gray-200 mb-6"></i>
+                <h3 class="text-lg font-bold text-gray-500">No hay requisitos definidos para este curso.</h3>
             </div>
         </div>
 
@@ -77,13 +77,13 @@
     <div x-data="{open: false}">
         <x-button type="button" color="indigo" x-on:click="open =!open">
             <i class="fa-solid fa-plus mr-1"></i>
-            <span>Nueva meta</span>
+            <span>Nuevo requisito</span>
         </x-button>
 
         <article class="card my-6 border border-gray-100 shadow-md"
                  x-show="open" x-collapse>
             <div class="px-6 py4 text-gray-700">
-                <h3 class="text-xl font-bold">Nueva meta</h3>
+                <h3 class="text-xl font-bold">Nuevo requisito</h3>
                 <hr class="mt-2 mb-6">
 
                 <form wire:submit.prevent="store" class="flex">
@@ -91,7 +91,7 @@
                             name="name"
                             type="text"
                             class="block w-full"
-                            placeholder="Escribe un nombre para esta meta"
+                            placeholder="Escribe un nombre para este requisito"
                             wire:model.live="name" />
                     <x-input-error for="name" class="ml-2" />
 

--- a/resources/views/teacher/courses/goals.blade.php
+++ b/resources/views/teacher/courses/goals.blade.php
@@ -4,10 +4,14 @@
 
         @include('teacher.includes.courses.aside')
 
-        <div class="card col-span-4">
+        <div class="col-span-4">
 
-            <div>
-                @livewire('teacher.courses-goals', ['course' => $course], key($course->id))
+            <div class="card  mb-8">
+                @livewire('teacher.courses-goals', ['course' => $course], key('courses-goals-' . $course->id))
+            </div>
+
+            <div class="card  mb-8">
+                @livewire('teacher.courses-requirements', ['course' => $course], key('courses-requirements-' . $course->id))
             </div>
 
         </div>

--- a/resources/views/teacher/courses/goals.blade.php
+++ b/resources/views/teacher/courses/goals.blade.php
@@ -5,11 +5,11 @@
         @include('teacher.includes.courses.aside')
 
         <div class="card col-span-4">
-            <h2 class="text-2xl font-bold">
-                <i class="fa-solid fa-list-check  mr-1"></i>
-                Metas y requisitos
-            </h2>
-            <hr class="mt-2 mb-6">
+
+            <div>
+                @livewire('teacher.courses-goals', ['course' => $course], key($course->id))
+            </div>
+
         </div>
 
     </div>

--- a/resources/views/teacher/courses/goals.blade.php
+++ b/resources/views/teacher/courses/goals.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+
+    <div class="container py-8 grid grid-cols-5">
+
+        @include('teacher.includes.courses.aside')
+
+        <div class="card col-span-4">
+            <h2 class="text-2xl font-bold">
+                <i class="fa-solid fa-list-check  mr-1"></i>
+                Metas y requisitos
+            </h2>
+            <hr class="mt-2 mb-6">
+        </div>
+
+    </div>
+
+</x-app-layout>

--- a/resources/views/teacher/includes/courses/aside.blade.php
+++ b/resources/views/teacher/includes/courses/aside.blade.php
@@ -14,7 +14,7 @@
         ],
         [
             'name' => 'Metas y requisitos',
-            'route' => '',
+            'route' => route('teacher.courses.edit.goals', $course),
             'icon' => 'fa-solid fa-list-check',
             'active' => request()->routeIs('teacher.courses.edit.goals'),
         ],

--- a/routes/teacher.php
+++ b/routes/teacher.php
@@ -14,3 +14,6 @@ Route::resource('courses', CourseController::class)
 
 Route::get('courses/{course}/edit/content', CoursesContent::class)
     ->name('courses.edit.content');
+
+Route::get('courses/{course}/edit/goals', [CourseController::class, 'goals'])
+    ->name('courses.edit.goals');


### PR DESCRIPTION
Con esta fusión implemento el apartado de edición de un curso donde el profesor puede definir las objetivos y requisitos de un curso, de modo que el usuario pueda saber fácilmente qué espera aprender con dicho curso, y qué conocimientos previos o materiales necesita para su realización.

Ambas secciones se encuentra en la misma vista, y cada una dispone de su propio marco, donde podemos gestionarlas, creando, editando o eliminando su contenido.

Para implementar el manejo de secciones he usado componentes de Livewire, y he incluido alertas visuales que se disparan cuando el profesor realice cambios en ellas.

![dabaliu test_8000_teacher_courses_mi-primer-curso_edit_goals(HD Laptop) (1)](https://github.com/edumarrom/pdaw23/assets/73343241/20825eed-c0fc-400d-ac82-a8c746371ceb)

![dabaliu test_8000_teacher_courses_mi-primer-curso_edit_goals(HD Laptop) (3)](https://github.com/edumarrom/pdaw23/assets/73343241/61b3df37-48fd-4552-b9ab-c7af9ac3c813)
