### PR TITLE
Proteger rutas y métodos del profesor

### DIFF
--- a/app/Http/Controllers/Teacher/CourseController.php
+++ b/app/Http/Controllers/Teacher/CourseController.php
@@ -96,6 +96,7 @@ class CourseController extends Controller
      */
     public function edit(Course $course)
     {
+        $this->authorize('delivered', $course);
 
         $categories = Category::all();
         $levels = Level::all();
@@ -109,6 +110,7 @@ class CourseController extends Controller
      */
     public function update(Request $request, Course $course)
     {
+        $this->authorize('delivered', $course);
         // return $request->all();
 
         $request->validate([
@@ -161,6 +163,7 @@ class CourseController extends Controller
 
     public function goals(Course $course)
     {
+        $this->authorize('delivered', $course);
         return view('teacher.courses.goals', compact('course'));
     }
 }

--- a/app/Livewire/Teacher/CoursesContent.php
+++ b/app/Livewire/Teacher/CoursesContent.php
@@ -18,6 +18,7 @@ class CoursesContent extends Component
 
     public function mount(Course $course)
     {
+        $this->authorize('delivered', $course);
         $this->course = $course;
         $this->section = new Section();
     }

--- a/app/Livewire/Teacher/CoursesStudents.php
+++ b/app/Livewire/Teacher/CoursesStudents.php
@@ -15,6 +15,7 @@ class CoursesStudents extends Component
 
     public function mount(Course $course)
     {
+        $this->authorize('delivered', $course);
         $this->course = $course;
     }
 

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -33,4 +33,13 @@ class CoursePolicy
     {
         return $course->status == 3;
     }
+
+    /**
+     * Comprueba si un usuario es el autor de un curso.
+     * @return bool
+     */
+    public function delivered(User $user, Course $course)
+    {
+        return $course->user_id == $user->id;
+    }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -41,7 +41,7 @@ class RouteServiceProvider extends ServiceProvider
                 ->name('admin.')
                 ->group(base_path('routes/admin.php'));
 
-            Route::middleware('web', 'auth')
+            Route::middleware('web', 'auth', 'can:teacher-cpanel')
                 ->prefix('teacher')
                 ->name('teacher.')
                 ->group(base_path('routes/teacher.php'));

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -18,6 +18,10 @@ class PermissionSeeder extends Seeder
             'name' => 'admin-cpanel',
         ]);
 
+        Permission::create([
+            'name' => 'teacher-cpanel',
+        ]);
+
         // Course permissions
         Permission::create([
             'name' => 'course-create',

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -19,6 +19,7 @@ class RoleSeeder extends Seeder
 
         $role->givePermissionTo([
             'admin-cpanel',
+            'teacher-cpanel',
             'course-create',
             'course-read',
             'course-edit',
@@ -30,6 +31,7 @@ class RoleSeeder extends Seeder
         ]);
 
         $role->givePermissionTo([
+            'teacher-cpanel',
             'course-create',
             'course-read',
             'course-edit',


### PR DESCRIPTION
En esta fusión implemento las restricciones necesarias para proteger las rutas relacionadas con la gestión de cursos de un profesor.

Para proteger las rutas hemos definido un nuevo permiso llamado `teacher-cpanel` el cual será aplicado en todas las rutas relacionadas con el profesor. Este permiso, se ha incluido en el seeder de permisos para que exista en el momento de la migración, y del mismo modo se lo he aplicado por defecto al usuario administrador.

Por otro lado he definido una nueva política para los cursos llamada `delivered`, con la que podemos comprobar si el usuario es quien imparte ese curso en la plataforma. Esto nos servirá para impedir que otros usuarios profesores puedan acceder a la gestión de un curso que no les pertenece. Para aplicar la politica se ha incluido mediante el método `authorize()` en aquellos métodos que muestran o modifican la información de un curso en concreto.

