### PR TITLE
Enviar emails tras revisión

### DIFF
--- a/app/Http/Controllers/Admin/CourseController.php
+++ b/app/Http/Controllers/Admin/CourseController.php
@@ -3,8 +3,10 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Mail\ApprovedCourse;
 use App\Models\Course;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 
 class CourseController extends Controller
@@ -32,6 +34,8 @@ class CourseController extends Controller
         ) {
             $course->status = Course::PUBLICADO;
             $course->save();
+
+            Mail::to($course->teacher->email)->send(new ApprovedCourse($course));
 
             session()->flash('swal', [
                 'icon' => 'success',

--- a/app/Mail/ApprovedCourse.php
+++ b/app/Mail/ApprovedCourse.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Course;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ApprovedCourse extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $course;
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(Course $course)
+    {
+        $this->course = $course;
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Tu curso ha sido aprobado',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.approved-course',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/resources/views/emails/approved-course.blade.php
+++ b/resources/views/emails/approved-course.blade.php
@@ -1,0 +1,12 @@
+<x-mail::message>
+# 🎉¡Enhorabuena!👌
+
+Te informamos que tu curso **"{{ $course->title }}"** ha sido aprobado y ya está disponible en la plataforma.
+
+<x-mail::button :url="''">
+Acceder a la plataforma
+</x-mail::button>
+
+Gracias por compartir tu conocimiento con nosotros ❤️,<br>
+El equipo de {{ config('app.name') }}.
+</x-mail::message>


### PR DESCRIPTION
En esta fusión implemento la capcidad de enviar un email de correo electrónico al profesor tras la revisión de su curso.

Dependiendo de si el curso ha sido aprobado o rechazado, recibirá un email notificándole. En el caso de ser un curso rechazado, se le indican recomendaciones para lograr que sea aprobado en próximas revisiones.

El envío de emails es gracias al servicio de emails que Laravel implementa a partir del componente Symphony Mailer. Para la elaboración del contenido del mensaje, he usado la funcionalidad de crear plantillas en lenguaje Markdown, con la que Laravel se encarga de elaborar la presentación del mensaje, a la que defino el contenido que debe mostrar en una plantilla blade, y mediante la sintaxis de Markdown puedo aplicar estilos fácilemente sobre el mismo.

## Referencias
- [Mail - Laravel 10.x doc [laravel.com]](https://laravel.com/docs/10.x/mail)
- [Crear plantilla de Email con Laravel 10 y enviar un correo [dev.to]](https://dev.to/drodero/crear-plantilla-de-email-con-laravel-10-y-enviar-un-correo-3ob4)

## capturas de pantalla
![mailtrap io_inboxes_2477272_messages_3965794319(HD Laptop)](https://github.com/edumarrom/pdaw23/assets/73343241/5b04264b-d1d6-48ad-aed5-a3d618fe8c60)


![mailtrap io_inboxes_2477272_messages_3965794319(HD Laptop) (1)](https://github.com/edumarrom/pdaw23/assets/73343241/ebef964a-261a-4205-a38d-0d9baabc3205)
