### PR TITLE
Incluir el buscador de cursos en la página de cursos

### DIFF
--- a/resources/views/courses/index.blade.php
+++ b/resources/views/courses/index.blade.php
@@ -11,11 +11,7 @@
                 </p>
 
                 {{-- Search bar --}}
-                <div class="pt-2 relative mx-auto text-gray-600">
-                    <input class=" w-full border-2 border-gray-300 bg-white h-10 px-5 pr-16 rounded-lg text-sm focus:outline-none focus:ring-indigo-500"
-                    type="search" name="search" placeholder="Figma desde cero...">
-                    <x-button class="absolute rounded-r-lg right-0 top-0 h-10 mt-2">Buscar</x-button>
-                </div>
+                @livewire('search')
 
             </div>
         </div>


### PR DESCRIPTION
A partir de la funcionalidad desarrollada en la anterior fusión #168, incluyo el componente de buscador de cursos en la página de cursos, para que el usuario pueda localizar de forma fácil y rápida un curso relacionado con lo que le interesa.

![dabaliu test_8000_courses(HD Laptop)](https://github.com/edumarrom/pdaw23/assets/73343241/0e2a99be-d123-4fa4-8dc6-e71f800852ee)
