### PR TITLE
closes #172; incluir timestamps al matricularse en un curso

### DIFF
--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -80,7 +80,7 @@ class Course extends Model
      */
     public function students()
     {
-        return $this->belongsToMany(User::class);
+        return $this->belongsToMany(User::class)->withTimestamps();
     }
 
     public function reviews()


### PR DESCRIPTION
Me percaté de la ausencia de esta información hace tiempo, pero hasta ahora no la he solventado.

Considero que puede ser útil en algunos contextos, como por ejemplo si queremos ordenar la lista de alumnos por fecha de matriculación, calcular el tiempo que han tardado en completar un curso, o consultar las matriculaciones de un curso en un periodo de tiempo concreto.

Incluyendo el método `withTimeStamps` a la relación `students` del modelo `Course` logramos que estos campos se mantengan de forma automática.

## Referencias
- [Retrieving Intermediate Table Columns [laravel.com]](https://laravel.com/docs/10.x/eloquent-relationships#retrieving-intermediate-table-columns)