### PR TITLE
Cursos relacionados

### DIFF
--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -199,7 +199,7 @@
             colRight.appendChild(relatedCoursesContainer);
 
             async function getRelatedCourses(limit = 5) {
-                const url = '{{ config('app.url') }}' + '/api/courses/category/' + '{{ $course->category->id}}';
+                const url = '{{ config('app.url') }}' + '/api/courses';
                 // console.log(url);
                 let count = 0;
 
@@ -212,7 +212,9 @@
                     const data = await response.json();
                     data.forEach(course => {
                         // console.log(course);
-                        if (count < limit && course.id != {{ $course->id }}) {
+                        if (count < limit
+                                && course.id != {{ $course->id }}
+                                && course.category.id == {{ $course->category->id }}) {
                             renderCourse(course);
                             count++;
                         }

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -227,7 +227,7 @@
                     const data = await response.json();
                     data.forEach(course => {
                         if (count < limit
-                                && course.id != {{ $course->id }}
+                                && course.slug != '{{ $course->slug }}'
                                 && course.category.id == {{ $course->category->id }}) {
                             renderCourse(course);
                             count++;

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -182,7 +182,6 @@
     </div>
 
     @push('scripts')
-
         {{-- Cursos relacionados --}}
         <script>
             const colLeft = document.querySelector('#col-left');
@@ -195,23 +194,16 @@
             relatedCoursesTitle.innerHTML = '<i class="fa-solid fa-layer-group mr-2"></i>Más cursos de <span class="font-bold">{{ $course->category->name }}</span>';
 
             const relatedCoursesCard = document.createElement('div');
-            relatedCoursesCard.classList.add('card', 'shadow-lg', 'space-y-4');
+            relatedCoursesCard.classList.add('card', 'shadow-lg');
 
             relatedCourses.appendChild(relatedCoursesTitle);
             relatedCourses.appendChild(relatedCoursesCard);
 
-            let numCourses = 4;
-            if (window.innerWidth < 1024) {
-                colLeft.appendChild(relatedCourses);
-                if (window.innerWidth > 768) {
-                    relatedCoursesCard.classList.add('grid', 'grid-cols-2', 'gap-4', 'space-y-0');
-                    numCourses = 6;
-                }
-            } else {
-                colRight.appendChild(relatedCourses);
-            }
-
+            numCourses = 4;
             getRelatedCourses(numCourses);
+            renderRelatedCourses();
+
+            window.addEventListener('resize', renderRelatedCourses);
 
             async function getRelatedCourses(limit = 5) {
                 const url = '{{ config('app.url') }}' + '/api/courses';
@@ -244,7 +236,7 @@
 
             function renderCourse(course) {
                 const courseCard = document.createElement('article');
-                courseCard.classList.add('px-4', 'py-2');
+                courseCard.classList.add('mb-2', 'px-4', 'py-2');
 
                 const courseImage = document.createElement('img');
                 courseImage.classList.add('h-auto', 'w-full', 'object-cover', 'object-center', 'flex-shrink-0', 'rounded', 'shadow');
@@ -304,6 +296,21 @@
 
                 relatedCoursesCard.appendChild(courseLink);
 
+            }
+
+            function renderRelatedCourses(courses) {
+                if (window.innerWidth < 1024) {
+                    if (window.innerWidth < 640) {
+                        relatedCoursesCard.classList.remove('grid', 'grid-cols-2', 'gap-4');
+                    } else {
+                        relatedCoursesCard.classList.add('grid', 'grid-cols-2', 'gap-4');
+                    }
+                    colLeft.appendChild(relatedCourses);
+                } else {
+                    numCourses = 4;
+                    relatedCoursesCard.classList.remove('grid', 'grid-cols-2', 'gap-4');
+                    colRight.appendChild(relatedCourses);
+                }
             }
 
         </script>

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -188,15 +188,30 @@
             const colLeft = document.querySelector('#col-left');
             const colRight = document.querySelector('#col-right');
 
+            const relatedCourses = document.createElement('section');
+
             const relatedCoursesTitle = document.createElement('h3');
             relatedCoursesTitle.classList.add('text-xl', 'text-gray-900', 'font-medium', 'mt-8', 'mb-2');
             relatedCoursesTitle.innerHTML = '<i class="fa-solid fa-layer-group mr-2"></i>Más cursos de <span class="font-bold">{{ $course->category->name }}</span>';
 
-            const relatedCoursesContainer = document.createElement('div');
-            relatedCoursesContainer.classList.add('card', 'shadow-lg', 'space-y-4');
+            const relatedCoursesCard = document.createElement('div');
+            relatedCoursesCard.classList.add('card', 'shadow-lg', 'space-y-4');
 
-            colRight.appendChild(relatedCoursesTitle);
-            colRight.appendChild(relatedCoursesContainer);
+            relatedCourses.appendChild(relatedCoursesTitle);
+            relatedCourses.appendChild(relatedCoursesCard);
+
+            let numCourses = 4;
+            if (window.innerWidth < 1024) {
+                colLeft.appendChild(relatedCourses);
+                if (window.innerWidth > 768) {
+                    relatedCoursesCard.classList.add('grid', 'grid-cols-2', 'gap-4', 'space-y-0');
+                    numCourses = 6;
+                }
+            } else {
+                colRight.appendChild(relatedCourses);
+            }
+
+            getRelatedCourses(numCourses);
 
             async function getRelatedCourses(limit = 5) {
                 const url = '{{ config('app.url') }}' + '/api/courses';
@@ -287,11 +302,9 @@
                 courseLink.href = '{{ config('app.url') }}' + '/courses/' + course.slug;
                 courseLink.appendChild(courseCard);
 
-                relatedCoursesContainer.appendChild(courseLink);
+                relatedCoursesCard.appendChild(courseLink);
 
             }
-
-            getRelatedCourses();
 
         </script>
 

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -38,10 +38,10 @@
     <div class="container mt-8 grid grid-cols-1 lg:grid-cols-3 gap-8">
 
         {{-- Columna izquierda --}}
-        <div class="lg:col-span-2 order-2 lg:order-1 space-y-12">
+        <div id="col-left" class="lg:col-span-2 order-2 lg:order-1 space-y-12">
 
             <section>
-                <h3 class="text-3xl font-bold mt-6 mb-2">
+                <h3 class="text-3xl text-gray-900 font-bold mt-6 mb-2">
                     <i class="fa fa-solid fa-circle-info mr-2"></i>
                     Acerca del curso
                 </h3>
@@ -52,7 +52,7 @@
             </section>
 
             <section>
-                <h3 class="text-3xl font-bold mt-6 mb-2">
+                <h3 class="text-3xl text-gray-900 font-bold mt-6 mb-2">
                     <i class="fa fa-solid fa-graduation-cap mr-2"></i>
                     Lo que aprenderás
                 </h3>
@@ -69,7 +69,7 @@
             </section>
 
             <section>
-                <h3 class="text-3xl font-bold mt-6 mb-2">
+                <h3 class="text-3xl text-gray-900 font-bold mt-6 mb-2">
                     <i class="fa fa-solid fa-list-check mr-2"></i>
                     Lo que debes saber
                 </h3>
@@ -86,7 +86,7 @@
             </section>
 
             <section>
-                <h3 class="text-3xl font-bold mt-6 mb-2">
+                <h3 class="text-3xl text-gray-900 font-bold mt-6 mb-2">
                     <i class="fa fa-solid fa-book mr-2"></i>
                     Contenido del curso
                 </h3>
@@ -132,7 +132,7 @@
         </div>
 
         {{-- Columna derecha --}}
-        <div id="course-info" class="order-1 lg:order-2 lg:relative lg:bottom-24">
+        <div id="col-right" class="order-1 lg:order-2 lg:relative lg:bottom-24">
             <section class="card shadow-lg space-y-4">
                 <div>
                     <div class="flex items-center mb-4">
@@ -185,21 +185,24 @@
 
         {{-- Cursos relacionados --}}
         <script>
-            const courseInfo = document.getElementById('course-info');
+            const colLeft = document.querySelector('#col-left');
+            const colRight = document.querySelector('#col-right');
 
             const relatedCoursesTitle = document.createElement('h3');
-            relatedCoursesTitle.classList.add('text-2xl', 'text-gray-800', 'font-bold', 'mt-6', 'mb-2');
-            relatedCoursesTitle.textContent = 'Cursos relacionados';
+            relatedCoursesTitle.classList.add('text-xl', 'text-gray-900', 'font-medium', 'mt-8', 'mb-2');
+            relatedCoursesTitle.innerHTML = '<i class="fa-solid fa-layer-group mr-2"></i>Más cursos de <span class="font-bold">{{ $course->category->name }}</span>';
 
             const relatedCoursesContainer = document.createElement('div');
             relatedCoursesContainer.classList.add('card', 'shadow-lg', 'space-y-4');
 
-            courseInfo.appendChild(relatedCoursesTitle);
-            courseInfo.appendChild(relatedCoursesContainer);
+            colRight.appendChild(relatedCoursesTitle);
+            colRight.appendChild(relatedCoursesContainer);
 
-            async function getRelatedCourses() {
+            async function getRelatedCourses(limit = 5) {
                 const url = '{{ config('app.url') }}' + '/api/courses/category/' + '{{ $course->category->id}}';
-                console.log(url);
+                // console.log(url);
+                let count = 0;
+
                 try {
                     const response = await fetch(url);
                     if (!response.ok) {
@@ -208,7 +211,11 @@
 
                     const data = await response.json();
                     data.forEach(course => {
-                        console.log(course);
+                        // console.log(course);
+                        if (count < limit && course.id != {{ $course->id }}) {
+                            renderCourse(course);
+                            count++;
+                        }
                     });
 
                     return data;
@@ -216,6 +223,70 @@
                     console.error('El error devuelto es:', error);
                     throw error;
                 }
+            }
+
+            function renderCourse(course) {
+                const courseCard = document.createElement('article');
+                courseCard.classList.add('px-4', 'py-2');
+
+                const courseImage = document.createElement('img');
+                courseImage.classList.add('h-auto', 'w-full', 'object-cover', 'object-center', 'flex-shrink-0', 'rounded', 'shadow');
+                courseImage.src = course.image;
+                courseImage.alt = course.title;
+
+                const courseInfo = document.createElement('div');
+
+                const courseTitle = document.createElement('h4');
+                courseTitle.classList.add('text-base', 'font-bold');
+                courseTitle.textContent = course.title;
+
+                const courseDetails = document.createElement('div');
+                courseDetails.classList.add('flex', 'justify-between', 'items-baseline');
+
+                const detailsList = document.createElement('ul');
+                detailsList.classList.add('flex', 'text-xs', 'space-x-4');
+
+                const rating = document.createElement('li');
+                rating.classList.add('text-gray-500');
+                rating.title = 'Valoración media';
+                rating.innerHTML = '<i class="fa-solid fa-star mr-1"></i>' + course.rating;
+
+                const students = document.createElement('li');
+                students.classList.add('text-gray-500');
+                students.title = 'Usuarios matriculados';
+                students.innerHTML = '<i class="fa-solid fa-users mr-1"></i>' + course.students;
+
+                const level = document.createElement('li');
+                level.classList.add('text-gray-500');
+                level.innerHTML = '<i class="fa-solid fa-cubes mr-1"></i>' + course.level.name;
+
+                detailsList.appendChild(rating);
+                detailsList.appendChild(students);
+                detailsList.appendChild(level);
+
+                const coursePrice = document.createElement('div');
+                coursePrice.classList.add('text-gray-700', 'text-lg', 'font-bold');
+                coursePrice.textContent = course.price;
+
+                courseDetails.appendChild(detailsList);
+                courseDetails.appendChild(coursePrice);
+
+                courseInfo.appendChild(courseTitle);
+                courseInfo.appendChild(courseDetails);
+
+                courseCard.appendChild(courseImage);
+                courseCard.appendChild(courseInfo);
+
+                /* courseCard.addEventListener('click', () => {
+                    window.location.href = '{{ config('app.url') }}' + '/courses/' + course.slug;
+                }); */
+
+                courseLink = document.createElement('a');
+                courseLink.href = '{{ config('app.url') }}' + '/courses/' + course.slug;
+                courseLink.appendChild(courseCard);
+
+                relatedCoursesContainer.appendChild(courseLink);
+
             }
 
             getRelatedCourses();

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -188,6 +188,7 @@
             const colRight = document.querySelector('#col-right');
 
             const relatedCourses = document.createElement('section');
+            relatedCourses.classList.add('hidden');
 
             const relatedCoursesTitle = document.createElement('h3');
             relatedCoursesTitle.classList.add('text-xl', 'text-gray-900', 'font-medium', 'mt-8', 'mb-2');
@@ -203,11 +204,18 @@
             getRelatedCourses(numCourses);
             renderRelatedCourses();
 
+            setTimeout(() => {
+                relatedCourses.classList.remove('hidden');
+            }, 500);
+
             window.addEventListener('resize', renderRelatedCourses);
 
-            async function getRelatedCourses(limit = 5) {
+            /*
+             * @requirement: DWECL - #15 DOM
+             * @requirement: DWECL - #19 Utilización de AJAX
+             */
+            async function getRelatedCourses(limit = 4) {
                 const url = '{{ config('app.url') }}' + '/api/courses';
-                // console.log(url);
                 let count = 0;
 
                 try {
@@ -218,7 +226,6 @@
 
                     const data = await response.json();
                     data.forEach(course => {
-                        // console.log(course);
                         if (count < limit
                                 && course.id != {{ $course->id }}
                                 && course.category.id == {{ $course->category->id }}) {
@@ -298,7 +305,7 @@
 
             }
 
-            function renderRelatedCourses(courses) {
+            function renderRelatedCourses() {
                 if (window.innerWidth < 1024) {
                     if (window.innerWidth < 640) {
                         relatedCoursesCard.classList.remove('grid', 'grid-cols-2', 'gap-4');

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -132,7 +132,7 @@
         </div>
 
         {{-- Columna derecha --}}
-        <div class="order-1 lg:order-2 lg:relative lg:bottom-24">
+        <div id="course-info" class="order-1 lg:order-2 lg:relative lg:bottom-24">
             <section class="card shadow-lg space-y-4">
                 <div>
                     <div class="flex items-center mb-4">
@@ -179,6 +179,49 @@
                 </div>
             </section>
         </div>
-
     </div>
+
+    @push('scripts')
+
+        {{-- Cursos relacionados --}}
+        <script>
+            const courseInfo = document.getElementById('course-info');
+
+            const relatedCoursesTitle = document.createElement('h3');
+            relatedCoursesTitle.classList.add('text-2xl', 'text-gray-800', 'font-bold', 'mt-6', 'mb-2');
+            relatedCoursesTitle.textContent = 'Cursos relacionados';
+
+            const relatedCoursesContainer = document.createElement('div');
+            relatedCoursesContainer.classList.add('card', 'shadow-lg', 'space-y-4');
+
+            courseInfo.appendChild(relatedCoursesTitle);
+            courseInfo.appendChild(relatedCoursesContainer);
+
+            async function getRelatedCourses() {
+                const url = '{{ config('app.url') }}' + '/api/courses/category/' + '{{ $course->category->id}}';
+                console.log(url);
+                try {
+                    const response = await fetch(url);
+                    if (!response.ok) {
+                    throw new Error('Se produjo un error al recuperar los datos');
+                    }
+
+                    const data = await response.json();
+                    data.forEach(course => {
+                        console.log(course);
+                    });
+
+                    return data;
+                } catch (error) {
+                    console.error('El error devuelto es:', error);
+                    throw error;
+                }
+            }
+
+            getRelatedCourses();
+
+        </script>
+
+    @endpush
+
 </x-app-layout>

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,7 +29,7 @@ Route::get('/courses/category/{categoryId}', function (Request $request) {
                     'title' => $course->title,
                     'slug' => $course->slug,
                     'teacher' => $course->teacher->name,
-                    'price' => $course->price->price,
+                    'price' => $course->priceEur,
                     'image' => $course->image ? $course->imagePath : null,
                     'rating' => $course->rating,
                     'students' => $course->students_count,

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,5 +45,6 @@ Route::get('/courses/category/{categoryId}', function (Request $request) {
                     'updated_at' => $course->updated_at,
                 ];
             })
+            ->values()
     );
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,3 +17,33 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::get('/courses/category/{categoryId}', function (Request $request) {
+    return response()->json(
+        App\Models\Course::all()
+            ->where('status', '3')
+            ->where('category_id', $request->categoryId)
+            ->sortByDesc('updated_at')
+            ->map(function ($course) {
+                return [
+                    'title' => $course->title,
+                    'slug' => $course->slug,
+                    'teacher' => $course->teacher->name,
+                    'price' => $course->price->price,
+                    'image' => $course->image ? $course->imagePath : null,
+                    'rating' => $course->rating,
+                    'students' => $course->students_count,
+                    'level' => [
+                        'id' => $course->level->id,
+                        'name' => $course->level->name,
+                    ],
+                    'category' => [
+                        'id' => $course->category->id,
+                        'name' => $course->category->name,
+                    ],
+                    'created_at' => $course->created_at,
+                    'updated_at' => $course->updated_at,
+                ];
+            })
+    );
+});

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,11 +18,10 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::get('/courses/category/{categoryId}', function (Request $request) {
+Route::get('/courses', function () {
     return response()->json(
         App\Models\Course::all()
             ->where('status', '3')
-            ->where('category_id', $request->categoryId)
             ->sortByDesc('updated_at')
             ->map(function ($course) {
                 return [


### PR DESCRIPTION
Con esta fusión implemento una la capacidad de mostrar en la ficha de un curso una lista de cursos relacionados con la categoría del curso que estemos viendo.

Para obtener los datos de los cursos he hecho uso de una función asíncrona #19, la cual solicita la relación de cursos existentes en la plataforma mediante una ruta API definida para esta finalidad. A la hora de procesar cada curso de la respuesta, comprobamos que el curso no sea el mismo que estamos viendo en la ficha y que pertenezca a la misma categoría.

El código HTML de dicha sección se define creando los elementos mediante JavaScript, y manipulando el DOM la insertamos en la página, que dependiendo de las dimensiones de la pantalla del dispositivo se mostrará:

## Ubicación responsiva

- En pantallas grandes: En la columna derecha, debajo de la tarjeta que muestra el profesor y el precio del curso.
- En pantallas medianas: En la columna izquierda, debajo de la sección de de valoraciones, en formato, com una grid de dos columnas.
- En pantallas pequeñas: En la misma ubicación que las pantallas medianas, pero como un bloque.

> Planteé la posibilidad de incluir los enlaces a los cursos mediante el manejo de un evento click, que de hecho permanece comentado en el código, pero se considera una mejor práctica el uso de enlaces `<a>` para garantizar una mejor accesibilidad, además de facilitar el rastreo y la indexación de dichos enlaces por parte de los motores de búsqueda.

## Capturas de pantalla
![chrome-capture-2024-1-22](https://github.com/edumarrom/pdaw23/assets/73343241/bf20c32a-2588-4ebf-a9db-1037621b687c)
