### PR TITLE
llamar al script de validacion solo en al vista checkout

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,2 +1,1 @@
 import './bootstrap';
-import './payment/checkout';

--- a/resources/views/payment/checkout.blade.php
+++ b/resources/views/payment/checkout.blade.php
@@ -117,4 +117,8 @@
         </div>
     </div>
 
+    @push('scripts')
+        <script src="{{Vite::asset('resources/js/payment/checkout.js')}}"></script>
+    @endpush
+
 </x-app-layout>


### PR DESCRIPTION
Cometí un error a la hora de cargar el script de validación del formulario de compra.

Tal como lo había planteado (importándolo en el fichero `resources/js/app.js`) estaba cargando el script de forma global, provocando un error que podíamos observar desde la consola del navegador.

Revisando la documentación de Laravel, he observado cómo llamar al scriptcorrectamente, haciendo que sólo se cargue en la vista de checkout.

Esto se logra usando el método `Vite::asset`, pasándole la ubicación del script como parámetro

## Referencia
- [Processing Static Assets With Vite [laravel.com]](https://laravel.com/docs/10.x/vite#blade-processing-static-assets)