### PR TITLE
Repasar apartado niveles

### DIFF
--- a/app/Http/Controllers/Admin/LevelController.php
+++ b/app/Http/Controllers/Admin/LevelController.php
@@ -39,7 +39,7 @@ class LevelController extends Controller
         session()->flash('swal', [
             'icon' => 'success',
             'title' => '¡Hecho!',
-            'text' => 'Nivel creado satisfactoriamente.',
+            'text' => "Nivel '$level->name' creado satisfactoriamente.",
         ]);
 
         return redirect()->route('admin.levels.index');

--- a/app/Http/Controllers/Admin/LevelController.php
+++ b/app/Http/Controllers/Admin/LevelController.php
@@ -43,15 +43,6 @@ class LevelController extends Controller
         ]);
 
         return redirect()->route('admin.levels.index');
-            /* ->with('success', 'Nivel creado satisfactoriamente.'); */
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(Level $level)
-    {
-        return view('admin.levels.show');
     }
 
     /**

--- a/app/Http/Controllers/Admin/LevelController.php
+++ b/app/Http/Controllers/Admin/LevelController.php
@@ -67,7 +67,7 @@ class LevelController extends Controller
         session()->flash('swal', [
             'icon' => 'success',
             'title' => '¡Hecho!',
-            'text' => 'Nivel editado satisfactoriamente.',
+            'text' => "Nivel '$level->name' editado satisfactoriamente.",
         ]);
 
         return redirect()->route('admin.levels.index');

--- a/app/Http/Controllers/Admin/LevelController.php
+++ b/app/Http/Controllers/Admin/LevelController.php
@@ -36,11 +36,7 @@ class LevelController extends Controller
 
         $level = Level::create($request->all());
 
-        session()->flash('swal', [
-            'icon' => 'success',
-            'title' => '¡Hecho!',
-            'text' => "Nivel '$level->name' creado satisfactoriamente.",
-        ]);
+        session()->flash('swal', $this->getSwalSuccess("Nivel '$level->name' creado satisfactoriamente"));
 
         return redirect()->route('admin.levels.index');
     }
@@ -64,11 +60,7 @@ class LevelController extends Controller
 
         $level->update($request->all());
 
-        session()->flash('swal', [
-            'icon' => 'success',
-            'title' => '¡Hecho!',
-            'text' => "Nivel '$level->name' editado satisfactoriamente.",
-        ]);
+        session()->flash('swal', $this->getSwalSuccess("Nivel '$level->name' editado satisfactoriamente"));
 
         return redirect()->route('admin.levels.index');
     }
@@ -81,28 +73,38 @@ class LevelController extends Controller
         $levelName = $level->name;
 
         if ($level->courses->count()) {
-            session()->flash('swal', [
-                'icon' => 'error',
-                'iconColor' => '#f43f5e',
-                'title' => "D'oh!",
-                'text' => "No es posible eliminar el nivel '$levelName' porque tiene cursos asociados.",
-                'confirmButtonText' => 'Aceptar',
-                'confirmButtonColor' => '#3b82f6',
-            ]);
+            session()->flash('swal', $this->getSwalError("No es posible eliminar el nivel '$levelName' porque tiene cursos asociados"));
 
             return redirect()->route('admin.levels.index');
         }
 
         $level->delete();
 
-        session()->flash('swal', [
-            'icon' => 'success',
-            'title' => '¡Hecho!',
-            'text' => "Nivel '$levelName' borrado satisfactoriamente.",
-            'confirmButtonText' => 'Aceptar',
-            'confirmButtonColor' => '#3b82f6',
-        ]);
+        session()->flash('swal', $this->getSwalSuccess("Nivel '$levelName' borrado satisfactoriamente"));
 
         return redirect()->route('admin.levels.index');
+    }
+
+    private function getSwalSuccess($text = '')
+    {
+        return [
+            'icon' => 'success',
+            'title' => '¡Hecho!',
+            'text' => $text,
+            'confirmButtonText' => 'Aceptar',
+            'confirmButtonColor' => '#3B82F6',
+        ];
+    }
+
+    private function getSwalError($text = '')
+    {
+        return [
+            'icon' => 'error',
+            'iconColor' => '#f43f5e',
+            'title' => "D'oh!",
+            'text' => $text,
+            'confirmButtonText' => 'Aceptar',
+            'confirmButtonColor' => '#3B82F6',
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/LevelController.php
+++ b/app/Http/Controllers/Admin/LevelController.php
@@ -8,6 +8,13 @@ use Illuminate\Http\Request;
 
 class LevelController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('can:level-read')->only('index');
+        $this->middleware('can:level-create')->only('create', 'store');
+        $this->middleware('can:level-edit')->only('edit', 'update', 'goals');
+        $this->middleware('can:level-delete')->only('destroy');
+    }
     /**
      * Display a listing of the resource.
      */

--- a/app/Http/Controllers/Admin/LevelController.php
+++ b/app/Http/Controllers/Admin/LevelController.php
@@ -78,12 +78,29 @@ class LevelController extends Controller
      */
     public function destroy(Level $level)
     {
+        $levelName = $level->name;
+
+        if ($level->courses->count()) {
+            session()->flash('swal', [
+                'icon' => 'error',
+                'iconColor' => '#f43f5e',
+                'title' => "D'oh!",
+                'text' => "No es posible eliminar el nivel '$levelName' porque tiene cursos asociados.",
+                'confirmButtonText' => 'Aceptar',
+                'confirmButtonColor' => '#3b82f6',
+            ]);
+
+            return redirect()->route('admin.levels.index');
+        }
+
         $level->delete();
 
         session()->flash('swal', [
             'icon' => 'success',
             'title' => '¡Hecho!',
-            'text' => 'Nivel borrado satisfactoriamente.',
+            'text' => "Nivel '$levelName' borrado satisfactoriamente.",
+            'confirmButtonText' => 'Aceptar',
+            'confirmButtonColor' => '#3b82f6',
         ]);
 
         return redirect()->route('admin.levels.index');

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -8,6 +8,10 @@ use Spatie\Permission\Models\Permission;
 
 class PermissionSeeder extends Seeder
 {
+    public $permissions = [
+        ['course-create', 'course-read', 'course-edit', 'course-delete'],
+        ['level-create', 'level-read', 'level-edit', 'level-delete'],
+    ];
     /**
      * Run the database seeds.
      */
@@ -22,21 +26,22 @@ class PermissionSeeder extends Seeder
             'name' => 'teacher-cpanel',
         ]);
 
-        // Course permissions
-        Permission::create([
-            'name' => 'course-create',
-        ]);
+        foreach ($this->permissions as $permission) {
+            Permission::create([
+                'name' => $permission[0],
+            ]);
 
-        Permission::create([
-            'name' => 'course-read',
-        ]);
+            Permission::create([
+                'name' => $permission[1],
+            ]);
 
-        Permission::create([
-            'name' => 'course-edit',
-        ]);
+            Permission::create([
+                'name' => $permission[2],
+            ]);
 
-        Permission::create([
-            'name' => 'course-delete',
-        ]);
+            Permission::create([
+                'name' => $permission[3],
+            ]);
+        }
     }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -8,29 +8,31 @@ use Spatie\Permission\Models\Role;
 
 class RoleSeeder extends Seeder
 {
+    public $permissions = [
+        'courses' => ['course-create', 'course-read', 'course-edit', 'course-delete'],
+        'levels' => ['level-create', 'level-read', 'level-edit', 'level-delete'],
+    ];
     /**
      * Run the database seeds.
      */
     public function run(): void
     {
-        $role = Role::create([
+        $admin = Role::create([
             'name' => 'admin',
         ]);
 
-        $role->givePermissionTo([
+        $admin->givePermissionTo([
             'admin-cpanel',
             'teacher-cpanel',
-            'course-create',
-            'course-read',
-            'course-edit',
-            'course-delete',
+            $this->permissions['courses'],
+            $this->permissions['levels'],
         ]);
 
-        $role = Role::create([
+        $teacher = Role::create([
             'name' => 'teacher',
         ]);
 
-        $role->givePermissionTo([
+        $teacher->givePermissionTo([
             'teacher-cpanel',
             'course-create',
             'course-read',

--- a/resources/js/levels/level-validation.js
+++ b/resources/js/levels/level-validation.js
@@ -1,0 +1,51 @@
+errorMessages = {
+  name: 'El campo nombre es obligatorio',
+}
+
+const form = document.querySelector('#level-form');
+form.addEventListener('submit', validateForm);
+
+function validateForm(event) {
+  event.preventDefault();
+  const name = document.getElementById('name').value;
+
+  const errors = {};
+  if (
+    name === null
+    || name.trim() === ''
+  ) {
+    errors.name = errorMessages.name;
+  }
+
+  if (Object.keys(errors).length > 0) {
+    showErrors(errors);
+  }
+  else {
+    form.submit();
+  }
+}
+
+function showErrors(errors) {
+  for (const key in errors) {
+    removeErrorMessage(key);
+    const errorMessage = createErrorMessage(key, errors[key]);
+    const input = document.getElementById(key);
+    input.classList.add('border-red-600');
+    input.insertAdjacentElement('afterend', errorMessage);
+  }
+}
+
+function createErrorMessage(key, message) {
+  const element = document.createElement('p');
+  element.id = key + '-error';
+  element.classList.add('text-sm', 'text-red-600', 'mt-2');
+  element.textContent = message;
+  return element;
+}
+
+function removeErrorMessage(key) {
+  const oldErrorMessage = document.getElementById(key + '-error');
+  if (oldErrorMessage) {
+    oldErrorMessage.remove();
+  }
+}

--- a/resources/views/admin/levels/create.blade.php
+++ b/resources/views/admin/levels/create.blade.php
@@ -4,20 +4,20 @@
             <h1 class="text-3xl font-bold">Nuevo nivel</h1>
         </div>
 
-        <form action="{{ route('admin.levels.store') }}" method="post"
+        <form id="level-form" action="{{ route('admin.levels.store') }}" method="post"
             class="card rounded-lg p-6 shadow-lg">
             @csrf
 
-            <x-validation-errors class="mb-4"/>
-
             <div class="mb-4">
                 <x-label for="name" class="mb-2" value="Nombre" />
-                <x-input name="name"
+                <x-input id="name"
+                         name="name"
                          type="text"
                          required
                          class="block w-full mb-2 focus:!border-blue-500 focus:!ring-blue-500"
                          placeholder="Escribe un nombre para este nivel"
                          value="{{old('name')}}" />
+                <x-input-error for="name" class="mt-2" />
             </div>
 
             <div class="flex justify-between mt-16">
@@ -33,4 +33,10 @@
             </div>
 
         </form>
+    </div>
+
+    @push('scripts')
+        <script src="{{Vite::asset('resources/js/levels/level-validation.js')}}"></script>
+    @endpush
+
 </x-admin-layout>

--- a/resources/views/admin/levels/create.blade.php
+++ b/resources/views/admin/levels/create.blade.php
@@ -1,36 +1,36 @@
 <x-admin-layout>
-    <div class="flex items-center justify-between mb-4">
-        <h1 class="text-3xl font-bold">Nuevo nivel</h1>
-    </div>
-
-    <form action="{{ route('admin.levels.store') }}" method="post"
-        class="bg-gray-100 rounded-lg p-6 shadow-lg">
-        @csrf
-
-        <x-validation-errors class="mb-4"/>
-
-        <div class="mb-4">
-            <x-label class="mb-2">
-                Nombre
-            </x-label>
-            <x-input
-                name="name"
-                class="w-full"
-                placeholder="Escribe el nombre del nuevo nivel"
-                value="{{old('name')}}"/>
+    <div class="md:container"></div>
+        <div class="flex items-center justify-between mb-4">
+            <h1 class="text-3xl font-bold">Nuevo nivel</h1>
         </div>
 
-        <div class="flex justify-between mt-16">
-            <x-link-button href="{{ url()->previous() }}">
-                <i class="fa-solid fa-xmark mr-2"></i>
-                Cancelar
-            </x-link-button>
+        <form action="{{ route('admin.levels.store') }}" method="post"
+            class="card rounded-lg p-6 shadow-lg">
+            @csrf
 
-            <x-button class="bg-blue-500 rounded hover:bg-blue-600">
-                <i class="fa-solid fa-save mr-2"></i>
-                Guardar
-            </x-button>
-        </div>
+            <x-validation-errors class="mb-4"/>
 
-    </form>
+            <div class="mb-4">
+                <x-label for="name" class="mb-2" value="Nombre" />
+                <x-input name="name"
+                         type="text"
+                         required
+                         class="block w-full mb-2 focus:!border-blue-500 focus:!ring-blue-500"
+                         placeholder="Escribe un nombre para este nivel"
+                         value="{{old('name')}}" />
+            </div>
+
+            <div class="flex justify-between mt-16">
+                <x-link-button href="{{ route('admin.levels.index') }}">
+                    <i class="fa-solid fa-xmark mr-2"></i>
+                    Cancelar
+                </x-link-button>
+
+                <x-button color="blue">
+                    <i class="fa-solid fa-save mr-2"></i>
+                    Guardar
+                </x-button>
+            </div>
+
+        </form>
 </x-admin-layout>

--- a/resources/views/admin/levels/edit.blade.php
+++ b/resources/views/admin/levels/edit.blade.php
@@ -1,35 +1,37 @@
 <x-admin-layout>
-    <div class="flex items-center justify-between mb-4">
-        <h1 class="text-3xl font-bold">Editar nivel</h1>
+    <div class="md:container">
+        <div class="flex items-center justify-between mb-4">
+            <h1 class="text-3xl font-bold">Editar nivel</h1>
+        </div>
+
+        <form action="{{ route('admin.levels.update', $level) }}" method="post"
+            class="card rounded-lg p-6 shadow-lg">
+            @method('PUT')
+            @csrf
+
+            <x-validation-errors class="mb-4" />
+
+            <div class="mb-4">
+                <x-label for="name" class="mb-2" value="Nombre" />
+                <x-input name="name"
+                         type="text"
+                         required
+                         class="block w-full mb-2 focus:!border-blue-500 focus:!ring-blue-500"
+                         placeholder="Escribe un nombre para este nivel"
+                         value="{{old('name', $level->name)}}" />
+            </div>
+
+            <div class="flex justify-between mt-16">
+                <x-link-button href="{{ route('admin.levels.index') }}">
+                    <i class="fa-solid fa-xmark mr-2"></i>
+                    Cancelar
+                </x-link-button>
+
+                <x-button color="blue">
+                    <i class="fa-solid fa-save mr-2"></i>
+                    Guardar
+                </x-button>
+            </div>
+        </form>
     </div>
-
-    <form action="{{ route('admin.levels.update', $level) }}" method="post"
-        class="bg-gray-100 rounded-lg p-6 shadow-lg">
-        @method('PUT')
-        @csrf
-
-        <x-validation-errors class="mb-4" />
-
-        <div class="mb-4">
-            <x-label class="mb-2">
-                Nombre
-            </x-label>
-            <x-input name="name"
-                     class="w-full"
-                     placeholder="Escribe un nombre para este nivel"
-                     value="{{old('name', $level->name)}}" />
-        </div>
-
-        <div class="flex justify-between mt-16">
-            <x-link-button href="{{ url()->previous() }}">
-                <i class="fa-solid fa-xmark mr-2"></i>
-                Cancelar
-            </x-link-button>
-
-            <x-button class="bg-blue-500 rounded hover:bg-blue-600">
-                <i class="fa-solid fa-save mr-2"></i>
-                Guardar
-            </x-button>
-        </div>
-    </form>
-</x-admin-layout>
+    </x-admin-layout>

--- a/resources/views/admin/levels/index.blade.php
+++ b/resources/views/admin/levels/index.blade.php
@@ -43,7 +43,7 @@
                                     @csrf
                                     @method('delete')
                                     <button type="button" class="text-rose-500 hover:text-rose-700"
-                                        onclick="deleteLevel({{ $level->id }})">
+                                        onclick="destroy({{ $level->id }})">
                                         <i class="fa-solid fa-trash"></i>
                                         Borrar
                                     </button>
@@ -58,16 +58,18 @@
 
     @push('scripts')
         <script>
-            function deleteLevel(levelId) {
-                const form = document.querySelector('#delete-form-' + levelId);
+            function destroy(elementId) {
+                const form = document.querySelector('#delete-form-' + elementId);
                 Swal.fire({
                     icon: 'warning',
+                    iconColor: '#f43f5e',
                     title: '¿Estás seguro?',
                     text: "Esta acción es irreversible",
                     showCancelButton: true,
                     confirmButtonText: 'Confirmar',
-                    confirmButtonColor: '#EF4444',
+                    confirmButtonColor: '#f43f5e',
                     cancelButtonText: 'Cancelar',
+                    cancelButtonColor: '#1f2937',
 
                 }).then((result) => {
                     if (result.isConfirmed) {

--- a/resources/views/admin/levels/index.blade.php
+++ b/resources/views/admin/levels/index.blade.php
@@ -1,58 +1,59 @@
 <x-admin-layout>
 
-    <div class="flex items-center justify-between mb-4">
-        <h1 class="text-3xl font-bold">Niveles</h1>
-        <x-link-button href="{{ route('admin.levels.create') }}"
-            class="bg-blue-500 rounded hover:bg-blue-600">
-            <i class="fa-solid fa-plus mr-2"></i>
-            Nuevo
-        </x-link-button>
-    </div>
+    <div class="md:container">
+        <div class="flex items-center justify-between mb-4">
+            <h1 class="text-3xl font-bold">Niveles</h1>
+            <x-link-button href="{{ route('admin.levels.create') }}" color="blue">
+                <i class="fa-solid fa-plus mr-2"></i>
+                Nuevo
+            </x-link-button>
+        </div>
 
-    <div class="relative overflow-x-auto">
-        <table class="w-full text-sm text-left text-gray-500">
-            <thead class="text-xs text-gray-700 uppercase bg-gray-50">
-                <tr>
-                    <th scope="col" class="px-6 py-3">
-                        ID
-                    </th>
-                    <th scope="col" class="px-6 py-3">
-                        Nombre
-                    </th>
-                    <th scope="col" class="px-6 py-3">
-                        Acciones
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach ($levels as $level)
-                    <tr class="bg-white border-b">
-                        <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap">
-                            {{ $level->id }}
+        <div class="relative overflow-x-auto rounded-lg shadow-xl">
+            <table class="w-full text-sm text-left text-gray-500">
+                <thead class="text-xs text-gray-700 uppercase bg-blue-100">
+                    <tr>
+                        <th scope="col" class="px-6 py-3 md:w-1/6 lg:w-1/12">
+                            ID
                         </th>
-                        <td class="px-6 py-4">
-                            {{ $level->name }}
-                        </td>
-                        <td class="px-6 py-4">
-                            <a href="{{ route('admin.levels.edit', $level) }}">
-                                <i class="fa-solid fa-pen"></i>
-                                Editar
-                            </a>
-                            <form action="{{ route('admin.levels.destroy', $level) }}" method="post"
-                                id='delete-form-{{ $level->id }}'>
-                                @csrf
-                                @method('delete')
-                                <button type="button" class="text-red-500"
-                                    onclick="deleteLevel({{ $level->id }})">
-                                    <i class="fa-solid fa-trash"></i>
-                                    Borrar
-                                </button>
-                            </form>
-                        </td>
+                        <th scope="col" class="px-6 py-3">
+                            Nombre
+                        </th>
+                        <th scope="col" class="px-6 py-3 md:w-1/3 lg:w-1/6">
+                            Acciones
+                        </th>
                     </tr>
-                @endforeach
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    @foreach ($levels as $level)
+                        <tr class="bg-white border-b hover:bg-gray-50">
+                            <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap">
+                                {{ $level->id }}
+                            </th>
+                            <td class="px-6 py-4">
+                                {{ $level->name }}
+                            </td>
+                            <td class="px-6 py-4">
+                                <a href="{{ route('admin.levels.edit', $level) }}" class="hover:text-gray-700">
+                                    <i class="fa-solid fa-pen"></i>
+                                    Editar
+                                </a>
+                                <form action="{{ route('admin.levels.destroy', $level) }}" method="post"
+                                    id='delete-form-{{ $level->id }}'>
+                                    @csrf
+                                    @method('delete')
+                                    <button type="button" class="text-rose-500 hover:text-rose-700"
+                                        onclick="deleteLevel({{ $level->id }})">
+                                        <i class="fa-solid fa-trash"></i>
+                                        Borrar
+                                    </button>
+                                </form>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
     </div>
 
     @push('scripts')

--- a/resources/views/admin/levels/show.blade.php
+++ b/resources/views/admin/levels/show.blade.php
@@ -1,3 +1,0 @@
-<x-admin-layout>
-    Mostrar nivel
-</x-admin-layout>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {return view('admin.dashboard');})->name('dashboard');
 
-Route::resource('/levels', LevelController::class)->names('levels');
+Route::resource('/levels', LevelController::class)->names('levels')->except('show');
 
 Route::resource('/roles', RoleController::class)->names('roles')->except('show');
 


### PR DESCRIPTION
En esta fusión hago un repaso sobre el apartado que permite al administrador gestionar los niveles de dificultad disponibles en la aplicación.

En relación al diseño he realizado una serie de correcciones sobre el estilo para que sea consistente con los demás apartados del cpanel del admin.

Respecto al lado del cliente los formularios ahora son validados mediante JavaScript #12, usando un diseño idéntico al que usa Laravel para mostrar los errores de validación, con el fin de que no se aprecie la diferencia entre un mensaje de error de validación desde el cliente o del servidor.

Del lado del servidor ahora se comprueba antes de borrar un nivel si está siendo usado por algun curso. En caso afirmativo devolverá un error notificando al usuario.

También he protegido los métodos del controlador mediante un middleware que determina qué permisos son necesarios para hacer uso de ellos. Por lo tanto, he creado los permisos necesarios en el despliegue actual, además de definirlos en el seeder de permisos y aplicarselos al usuario administrador para que estén disponible desde la migración inicial de la aplicación.

Por último simplificado la forma en que se construyen los mensajes modales generados con SweetAlert2, creando dos métodos que nos preparan los datos comunes a cualquier alerta, dependiendo de si se trata de una alerta de éxito o de error, y reciben como parámetro el mensaje que queremos mostrar con la alerta.