### PR TITLE
Crear apartado categorias

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -22,7 +22,7 @@ class CategoryController extends Controller
      */
     public function create()
     {
-        //
+        return view('admin.categories.create');
     }
 
     /**
@@ -30,30 +30,81 @@ class CategoryController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        $request->validate([
+            'name' => 'required|string|max:255|unique:categories',
+        ]);
+
+        $category = Category::create($request->all());
+
+        session()->flash('swal', $this->getSwalSuccess("Categoría '$category->name' creada satisfactoriamente"));
+
+        return redirect()->route('admin.categories.index');
     }
 
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(string $id)
+    public function edit(Category $category)
     {
-        //
+        return view('admin.categories.edit', compact('category'));
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(Request $request, Category $category)
     {
-        //
+        $request->validate([
+            'name' => 'required|string|max:255|unique:categories,name,' . $category->id,
+        ]);
+
+        $category->update($request->all());
+
+        session()->flash('swal', $this->getSwalSuccess("Nivel '$category->name' editada satisfactoriamente"));
+
+        return redirect()->route('admin.categories.index');
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id)
+    public function destroy(Category $category)
     {
-        //
+        $categoryName = $category->name;
+
+        if ($category->courses->count()) {
+            session()->flash('swal', $this->getSwalError("No es posible eliminar el nivel '$categoryName' porque tiene cursos asociados"));
+
+            return redirect()->route('admin.categories.index');
+        }
+
+        $category->delete();
+
+        session()->flash('swal', $this->getSwalSuccess("Nivel '$categoryName' borrada satisfactoriamente"));
+
+        return redirect()->route('admin.categories.index');
+    }
+
+    private function getSwalSuccess($text = '')
+    {
+        return [
+            'icon' => 'success',
+            'title' => '¡Hecho!',
+            'text' => $text,
+            'confirmButtonText' => 'Aceptar',
+            'confirmButtonColor' => '#3B82F6',
+        ];
+    }
+
+    private function getSwalError($text = '')
+    {
+        return [
+            'icon' => 'error',
+            'iconColor' => '#f43f5e',
+            'title' => "D'oh!",
+            'text' => $text,
+            'confirmButtonText' => 'Aceptar',
+            'confirmButtonColor' => '#3B82F6',
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -8,6 +8,14 @@ use Illuminate\Http\Request;
 
 class CategoryController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('can:category-read')->only('index');
+        $this->middleware('can:category-create')->only('create', 'store');
+        $this->middleware('can:category-edit')->only('edit', 'update');
+        $this->middleware('can:category-delete')->only('destroy');
+    }
+
     /**
      * Display a listing of the resource.
      */

--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Category;
+use Illuminate\Http\Request;
+
+class CategoryController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $categories = Category::all();
+        return view('admin.categories.index', compact('categories'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -9,6 +9,8 @@ class Category extends Model
 {
     use HasFactory;
 
+    protected $fillable = ['name'];
+
     public function courses()
     {
         return $this->hasMany(Course::class);

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -8,9 +8,10 @@ use Spatie\Permission\Models\Permission;
 
 class PermissionSeeder extends Seeder
 {
-    public $permissions = [
-        ['course-create', 'course-read', 'course-edit', 'course-delete'],
-        ['level-create', 'level-read', 'level-edit', 'level-delete'],
+    private $models = [
+        'category',
+        'level',
+        'course',
     ];
     /**
      * Run the database seeds.
@@ -26,22 +27,18 @@ class PermissionSeeder extends Seeder
             'name' => 'teacher-cpanel',
         ]);
 
-        foreach ($this->permissions as $permission) {
-            Permission::create([
-                'name' => $permission[0],
-            ]);
+        $this->bulkCreatePermissions($this->models);
+    }
 
-            Permission::create([
-                'name' => $permission[1],
-            ]);
-
-            Permission::create([
-                'name' => $permission[2],
-            ]);
-
-            Permission::create([
-                'name' => $permission[3],
-            ]);
+    private function bulkCreatePermissions($models)
+    {
+        foreach ($models as $model){
+            $actions = ['create', 'read', 'edit', 'delete'];
+            foreach ($actions as $action){
+                Permission::create([
+                    'name' => $model . '-' . $action,
+                ]);
+            }
         }
     }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -40,10 +40,6 @@ class RoleSeeder extends Seeder
             'course-edit',
             'course-delete',
         ]);
-
-        Role::create([
-            'name' => 'student',
-        ]);
     }
 
     /* private function getCrudPermissions($model)

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -8,9 +8,10 @@ use Spatie\Permission\Models\Role;
 
 class RoleSeeder extends Seeder
 {
-    public $permissions = [
-        'courses' => ['course-create', 'course-read', 'course-edit', 'course-delete'],
-        'levels' => ['level-create', 'level-read', 'level-edit', 'level-delete'],
+    private $models = [
+        'category',
+        'level',
+        'course',
     ];
     /**
      * Run the database seeds.
@@ -24,9 +25,9 @@ class RoleSeeder extends Seeder
         $admin->givePermissionTo([
             'admin-cpanel',
             'teacher-cpanel',
-            $this->permissions['courses'],
-            $this->permissions['levels'],
         ]);
+
+        $this->bulkGivePermissions($admin, $this->models);
 
         $teacher = Role::create([
             'name' => 'teacher',
@@ -43,5 +44,26 @@ class RoleSeeder extends Seeder
         Role::create([
             'name' => 'student',
         ]);
+    }
+
+    /* private function getCrudPermissions($model)
+    {
+        $permissions = [];
+        $actions = ['create', 'read', 'edit', 'delete'];
+        foreach ($actions as $action){
+            $permissions[] = $model . '-' . $action;
+        }
+
+        return $permissions;
+    } */
+
+    private function bulkGivePermissions($role, $models)
+    {
+        foreach ($models as $model){
+            $actions = ['create', 'read', 'edit', 'delete'];
+            foreach ($actions as $action){
+                $role->givePermissionTo($model . '-' . $action);
+            }
+        }
     }
 }

--- a/resources/js/categories/validation.js
+++ b/resources/js/categories/validation.js
@@ -1,0 +1,51 @@
+errorMessages = {
+  name: 'El campo nombre es obligatorio',
+}
+
+const form = document.querySelector('#category-form');
+form.addEventListener('submit', validateForm);
+
+function validateForm(event) {
+  event.preventDefault();
+  const name = document.getElementById('name').value;
+
+  const errors = {};
+  if (
+    name === null
+    || name.trim() === ''
+  ) {
+    errors.name = errorMessages.name;
+  }
+
+  if (Object.keys(errors).length > 0) {
+    showErrors(errors);
+  }
+  else {
+    form.submit();
+  }
+}
+
+function showErrors(errors) {
+  for (const key in errors) {
+    removeErrorMessage(key);
+    const errorMessage = createErrorMessage(key, errors[key]);
+    const input = document.getElementById(key);
+    input.classList.add('border-red-600');
+    input.insertAdjacentElement('afterend', errorMessage);
+  }
+}
+
+function createErrorMessage(key, message) {
+  const element = document.createElement('p');
+  element.id = key + '-error';
+  element.classList.add('text-sm', 'text-red-600', 'mt-2');
+  element.textContent = message;
+  return element;
+}
+
+function removeErrorMessage(key) {
+  const oldErrorMessage = document.getElementById(key + '-error');
+  if (oldErrorMessage) {
+    oldErrorMessage.remove();
+  }
+}

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -1,0 +1,40 @@
+<x-admin-layout>
+    <div class="md:container"></div>
+        <div class="flex items-center justify-between mb-4">
+            <h1 class="text-3xl font-bold">Nueva Categoría</h1>
+        </div>
+
+        <form id="category-form" action="{{ route('admin.categories.store') }}" method="post"
+            class="card rounded-lg p-6 shadow-lg">
+            @csrf
+
+            <div class="mb-4">
+                <x-label for="name" class="mb-2" value="Nombre" />
+                <x-input id="name"
+                         name="name"
+                         type="text"
+                         required
+                         class="block w-full mb-2 focus:!border-blue-500 focus:!ring-blue-500"
+                         placeholder="Escribe un nombre para esta categoría"
+                         value="{{old('name')}}" />
+                <x-input-error for="name" class="mt-2" />
+            </div>
+
+            <div class="flex justify-between mt-16">
+                <x-link-button href="{{ route('admin.categories.index') }}">
+                    <i class="fa-solid fa-xmark mr-2"></i>
+                    Cancelar
+                </x-link-button>
+
+                <x-button color="blue">
+                    <i class="fa-solid fa-save mr-2"></i>
+                    Guardar
+                </x-button>
+            </div>
+
+        </form>
+    </div>
+    @push('scripts')
+        <script src="{{Vite::asset('resources/js/categories/validation.js')}}"></script>
+    @endpush
+</x-admin-layout>

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -1,5 +1,5 @@
 <x-admin-layout>
-    <div class="md:container"></div>
+    <div class="md:container">
         <div class="flex items-center justify-between mb-4">
             <h1 class="text-3xl font-bold">Nueva Categoría</h1>
         </div>

--- a/resources/views/admin/categories/edit.blade.php
+++ b/resources/views/admin/categories/edit.blade.php
@@ -4,21 +4,21 @@
             <h1 class="text-3xl font-bold">Editar categoría</h1>
         </div>
 
-        <form action="{{ route('admin.categories.update', $category) }}" method="post"
+        <form id="category-form"  action="{{ route('admin.categories.update', $category) }}" method="post"
             class="card rounded-lg p-6 shadow-lg">
             @method('PUT')
             @csrf
 
-            <x-validation-errors class="mb-4" />
-
             <div class="mb-4">
                 <x-label for="name" class="mb-2" value="Nombre" />
-                <x-input name="name"
+                <x-input id="name"
+                         name="name"
                          type="text"
                          required
                          class="block w-full mb-2 focus:!border-blue-500 focus:!ring-blue-500"
                          placeholder="Escribe un nombre para este categoría"
                          value="{{old('name', $category->name)}}" />
+                <x-input-error for="name" class="mt-2" />
             </div>
 
             <div class="flex justify-between mt-16">

--- a/resources/views/admin/categories/edit.blade.php
+++ b/resources/views/admin/categories/edit.blade.php
@@ -1,0 +1,40 @@
+<x-admin-layout>
+    <div class="md:container">
+        <div class="flex items-center justify-between mb-4">
+            <h1 class="text-3xl font-bold">Editar categoría</h1>
+        </div>
+
+        <form action="{{ route('admin.categories.update', $category) }}" method="post"
+            class="card rounded-lg p-6 shadow-lg">
+            @method('PUT')
+            @csrf
+
+            <x-validation-errors class="mb-4" />
+
+            <div class="mb-4">
+                <x-label for="name" class="mb-2" value="Nombre" />
+                <x-input name="name"
+                         type="text"
+                         required
+                         class="block w-full mb-2 focus:!border-blue-500 focus:!ring-blue-500"
+                         placeholder="Escribe un nombre para este categoría"
+                         value="{{old('name', $category->name)}}" />
+            </div>
+
+            <div class="flex justify-between mt-16">
+                <x-link-button href="{{ route('admin.categories.index') }}">
+                    <i class="fa-solid fa-xmark mr-2"></i>
+                    Cancelar
+                </x-link-button>
+
+                <x-button color="blue">
+                    <i class="fa-solid fa-save mr-2"></i>
+                    Guardar
+                </x-button>
+            </div>
+        </form>
+    </div>
+    @push('scripts')
+        <script src="{{Vite::asset('resources/js/categories/validation.js')}}"></script>
+    @endpush
+    </x-admin-layout>

--- a/resources/views/admin/categories/index.blade.php
+++ b/resources/views/admin/categories/index.blade.php
@@ -1,0 +1,82 @@
+<x-admin-layout>
+
+    <div class="md:container">
+        <div class="flex items-center justify-between mb-4">
+            <h1 class="text-3xl font-bold">Categorías</h1>
+            <x-link-button href="{{ route('admin.categories.create') }}" color="blue">
+                <i class="fa-solid fa-plus mr-2"></i>
+                Nuevo
+            </x-link-button>
+        </div>
+
+        <div class="relative overflow-x-auto rounded-lg shadow-xl">
+            <table class="w-full text-sm text-left text-gray-500">
+                <thead class="text-xs text-gray-700 uppercase bg-blue-100">
+                    <tr>
+                        <th scope="col" class="px-6 py-3 md:w-1/6 lg:w-1/12">
+                            ID
+                        </th>
+                        <th scope="col" class="px-6 py-3">
+                            Nombre
+                        </th>
+                        <th scope="col" class="px-6 py-3 md:w-1/3 lg:w-1/6">
+                            Acciones
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($categories as $category)
+                        <tr class="bg-white border-b hover:bg-gray-50">
+                            <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap">
+                                {{ $category->id }}
+                            </th>
+                            <td class="px-6 py-4">
+                                {{ $category->name }}
+                            </td>
+                            <td class="px-6 py-4">
+                                <a href="{{ route('admin.categories.edit', $category) }}" class="hover:text-gray-700">
+                                    <i class="fa-solid fa-pen"></i>
+                                    Editar
+                                </a>
+                                <form action="{{ route('admin.categories.destroy', $category) }}" method="post"
+                                    id='delete-form-{{ $category->id }}'>
+                                    @csrf
+                                    @method('delete')
+                                    <button type="button" class="text-rose-500 hover:text-rose-700"
+                                        onclick="destroy({{ $category->id }})">
+                                        <i class="fa-solid fa-trash"></i>
+                                        Borrar
+                                    </button>
+                                </form>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    @push('scripts')
+        <script>
+            function destroy(elementId) {
+                const form = document.querySelector('#delete-form-' + elementId);
+                Swal.fire({
+                    icon: 'warning',
+                    iconColor: '#f43f5e',
+                    title: '¿Estás seguro?',
+                    text: "Esta acción es irreversible",
+                    showCancelButton: true,
+                    confirmButtonText: 'Confirmar',
+                    confirmButtonColor: '#f43f5e',
+                    cancelButtonText: 'Cancelar',
+                    cancelButtonColor: '#1f2937',
+
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        form.submit()
+                    }
+                })
+            }
+        </script>
+    @endpush
+</x-admin-layout>

--- a/resources/views/layouts/includes/admin/aside.blade.php
+++ b/resources/views/layouts/includes/admin/aside.blade.php
@@ -12,12 +12,20 @@
             'icon' => 'fa-solid fa-book',
             'active' => request()->routeIs('admin.courses.*'),
         ],
+        [],
+        [
+            'name' => 'Categorías',
+            'route' => route('admin.categories.index'),
+            'icon' => 'fa-solid fa-layer-group',
+            'active' => request()->routeIs('admin.categories.*'),
+        ],
         [
             'name' => 'Niveles',
             'route' => route('admin.levels.index'),
-            'icon' => 'fa-solid fa-layer-group',
+            'icon' => 'fa-solid fa-cubes',
             'active' => request()->routeIs('admin.levels.*'),
         ],
+        [],
         [
             'name' => 'Usuarios',
             'route' => route('admin.users.index'),
@@ -25,16 +33,16 @@
             'active' => request()->routeIs('admin.users.*'),
         ],
         [
-            'name' => 'Permisos',
-            'route' => route('admin.permissions.index'),
-            'icon' => 'fa-solid fa-user-shield',
-            'active' => request()->routeIs('admin.permissions.*'),
-        ],
-        [
             'name' => 'Roles',
             'route' => route('admin.roles.index'),
             'icon' => 'fa-solid fa-user-gear',
             'active' => request()->routeIs('admin.roles.*'),
+        ],
+        [
+            'name' => 'Permisos',
+            'route' => route('admin.permissions.index'),
+            'icon' => 'fa-solid fa-user-shield',
+            'active' => request()->routeIs('admin.permissions.*'),
         ],
     ]
 @endphp
@@ -47,16 +55,21 @@
         <ul class="space-y-2 font-medium">
 
             @foreach ($links as $link)
-                <li>
-                    <a  href="{{ $link['route'] }}"
-                        class="flex items-center p-2 text-gray-900 rounded-lg hover:bg-gray-100 hover:cursor-pointer
-                        {{ $link['active'] ? 'bg-gray-100' : '' }}">
+                {{-- si el el array $link está vacío --}}
+                @empty($link)
+                    <hr>
+                @else
+                    <li>
+                        <a  href="{{ $link['route'] }}"
+                            class="flex items-center p-2 text-gray-900 rounded-lg hover:bg-gray-100 hover:cursor-pointer
+                            {{ $link['active'] ? 'bg-gray-100' : '' }}">
 
-                        <i class="mr-3 text-xl text-gray-500 {{$link['icon']}}"></i>
+                            <i class="mr-3 text-xl text-gray-500 {{$link['icon']}}"></i>
 
-                        <span class="ms-3">{{ $link['name'] }}</span>
-                    </a>
-                </li>
+                            <span class="ms-3">{{ $link['name'] }}</span>
+                        </a>
+                    </li>
+                @endempty
             @endforeach
 
         </ul>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\CourseController;
 use App\Http\Controllers\Admin\LevelController;
 use App\Http\Controllers\Admin\PermissionController;
@@ -17,6 +18,8 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {return view('admin.dashboard');})->name('dashboard');
 
 Route::resource('/levels', LevelController::class)->names('levels')->except('show');
+
+Route::resource('/categories', CategoryController::class)->names('categories')->except('show');
 
 Route::resource('/roles', RoleController::class)->names('roles')->except('show');
 


### PR DESCRIPTION
Con esta fusión implemento el apartado para gestionar las categorías de la aplicación.

Para realizarlo he definido la nueva ruta `resource` sin la ruta `show`, incluido la opción en el menú lateral del panel administrativo, y copiado el controlador y las vistas de niveles, adaptándolo para usarlos con categorias.

He simplificado la forma en que se definen los permisos y los roles en los seeders, para que se puedan crear y asignar de forma masiva.