### PR TITLE
Repasar apartado roles

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -12,7 +12,7 @@ class CategoryController extends Controller
     {
         $this->middleware('can:category-read')->only('index');
         $this->middleware('can:category-create')->only('create', 'store');
-        $this->middleware('can:category-edit')->only('edit', 'update');
+        $this->middleware('can:category-update')->only('edit', 'update');
         $this->middleware('can:category-delete')->only('destroy');
     }
 

--- a/app/Http/Controllers/Admin/LevelController.php
+++ b/app/Http/Controllers/Admin/LevelController.php
@@ -12,7 +12,7 @@ class LevelController extends Controller
     {
         $this->middleware('can:level-read')->only('index');
         $this->middleware('can:level-create')->only('create', 'store');
-        $this->middleware('can:level-edit')->only('edit', 'update');
+        $this->middleware('can:level-update')->only('edit', 'update');
         $this->middleware('can:level-delete')->only('destroy');
     }
     /**

--- a/app/Http/Controllers/Admin/PriceController.php
+++ b/app/Http/Controllers/Admin/PriceController.php
@@ -12,7 +12,7 @@ class PriceController extends Controller
     {
         $this->middleware('can:price-read')->only('index');
         $this->middleware('can:price-create')->only('create', 'store');
-        $this->middleware('can:price-edit')->only('edit', 'update');
+        $this->middleware('can:price-update')->only('edit', 'update');
         $this->middleware('can:price-delete')->only('destroy');
     }
 

--- a/app/Http/Controllers/Admin/RoleController.php
+++ b/app/Http/Controllers/Admin/RoleController.php
@@ -9,6 +9,14 @@ use Spatie\Permission\Models\Role;
 
 class RoleController extends Controller
 {
+    private $models = [
+        'role',
+        'category',
+        'level',
+        'course',
+        'price',
+    ];
+
     public function __construct()
     {
         $this->middleware('can:role-read')->only('index');
@@ -31,9 +39,10 @@ class RoleController extends Controller
      */
     public function create()
     {
-        $permissions = Permission::where('name', '!=', 'admin-cpanel')
-            ->where('name', '!=', 'teacher-cpanel')
-            ->get()
+        $permissions = Permission::all()
+            ->filter(function ($permission) {
+                return in_array(explode('-', $permission->name)[0], $this->models);
+            })
             ->groupBy(function ($permission) {
                 return explode('-', $permission->name)[0];
             });
@@ -64,9 +73,10 @@ class RoleController extends Controller
      */
     public function edit(Role $role)
     {
-        $permissions = Permission::where('name', '!=', 'admin-cpanel')
-            ->where('name', '!=', 'teacher-cpanel')
-            ->get()
+        $permissions = Permission::all()
+            ->filter(function ($permission) {
+                return in_array(explode('-', $permission->name)[0], $this->models);
+            })
             ->groupBy(function ($permission) {
                 return explode('-', $permission->name)[0];
             });

--- a/app/Http/Controllers/Admin/RoleController.php
+++ b/app/Http/Controllers/Admin/RoleController.php
@@ -13,7 +13,7 @@ class RoleController extends Controller
     {
         $this->middleware('can:role-read')->only('index');
         $this->middleware('can:role-create')->only('create', 'store');
-        $this->middleware('can:role-edit')->only('edit', 'update');
+        $this->middleware('can:role-update')->only('edit', 'update');
         $this->middleware('can:role-delete')->only('destroy');
     }
 
@@ -31,8 +31,12 @@ class RoleController extends Controller
      */
     public function create()
     {
-
-        $permissions = Permission::all();
+        $permissions = Permission::where('name', '!=', 'admin-cpanel')
+            ->where('name', '!=', 'teacher-cpanel')
+            ->get()
+            ->groupBy(function ($permission) {
+                return explode('-', $permission->name)[0];
+            });
 
         return view('admin.roles.create', compact('permissions'));
     }
@@ -60,7 +64,12 @@ class RoleController extends Controller
      */
     public function edit(Role $role)
     {
-        $permissions = Permission::all();
+        $permissions = Permission::where('name', '!=', 'admin-cpanel')
+            ->where('name', '!=', 'teacher-cpanel')
+            ->get()
+            ->groupBy(function ($permission) {
+                return explode('-', $permission->name)[0];
+            });
 
         return view('admin.roles.edit', compact('role', 'permissions'));
     }

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -9,6 +9,7 @@ use Spatie\Permission\Models\Permission;
 class PermissionSeeder extends Seeder
 {
     private $models = [
+        'role',
         'category',
         'level',
         'price',
@@ -34,7 +35,7 @@ class PermissionSeeder extends Seeder
     private function bulkCreatePermissions($models)
     {
         foreach ($models as $model){
-            $actions = ['create', 'read', 'edit', 'delete'];
+            $actions = ['create', 'read', 'update', 'delete'];
             foreach ($actions as $action){
                 Permission::create([
                     'name' => $model . '-' . $action,

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -9,6 +9,7 @@ use Spatie\Permission\Models\Role;
 class RoleSeeder extends Seeder
 {
     private $models = [
+        'role',
         'category',
         'level',
         'course',
@@ -38,7 +39,7 @@ class RoleSeeder extends Seeder
             'teacher-cpanel',
             'course-create',
             'course-read',
-            'course-edit',
+            'course-update',
             'course-delete',
         ]);
     }
@@ -46,7 +47,7 @@ class RoleSeeder extends Seeder
     /* private function getCrudPermissions($model)
     {
         $permissions = [];
-        $actions = ['create', 'read', 'edit', 'delete'];
+        $actions = ['create', 'read', 'update', 'delete'];
         foreach ($actions as $action){
             $permissions[] = $model . '-' . $action;
         }
@@ -57,7 +58,7 @@ class RoleSeeder extends Seeder
     private function bulkGivePermissions($role, $models)
     {
         foreach ($models as $model){
-            $actions = ['create', 'read', 'edit', 'delete'];
+            $actions = ['create', 'read', 'update', 'delete'];
             foreach ($actions as $action){
                 $role->givePermissionTo($model . '-' . $action);
             }

--- a/resources/js/roles/validation.js
+++ b/resources/js/roles/validation.js
@@ -1,0 +1,51 @@
+errorMessages = {
+  name: 'El campo nombre es obligatorio',
+}
+
+const form = document.querySelector('#role-form');
+form.addEventListener('submit', validateForm);
+
+function validateForm(event) {
+  event.preventDefault();
+  const name = document.getElementById('name').value;
+
+  const errors = {};
+  if (
+    name === null
+    || name.trim() === ''
+  ) {
+    errors.name = errorMessages.name;
+  }
+
+  if (Object.keys(errors).length > 0) {
+    showErrors(errors);
+  }
+  else {
+    form.submit();
+  }
+}
+
+function showErrors(errors) {
+  for (const key in errors) {
+    removeErrorMessage(key);
+    const errorMessage = createErrorMessage(key, errors[key]);
+    const input = document.getElementById(key);
+    input.classList.add('border-red-600');
+    input.insertAdjacentElement('afterend', errorMessage);
+  }
+}
+
+function createErrorMessage(key, message) {
+  const element = document.createElement('p');
+  element.id = key + '-error';
+  element.classList.add('text-sm', 'text-red-600', 'mt-2');
+  element.textContent = message;
+  return element;
+}
+
+function removeErrorMessage(key) {
+  const oldErrorMessage = document.getElementById(key + '-error');
+  if (oldErrorMessage) {
+    oldErrorMessage.remove();
+  }
+}

--- a/resources/views/admin/roles/create.blade.php
+++ b/resources/views/admin/roles/create.blade.php
@@ -20,7 +20,7 @@
                          value="{{old('name')}}" />
             </div>
 
-            <div class="mb-4">
+            {{-- <div class="mb-4">
                 <p class="mb-2 font-medium text-sm text-gray-700">Permisos</p>
                 <ul>
                     @foreach ($permissions as $permission)
@@ -37,6 +37,53 @@
                         </x-label>
                     @endforeach
                 </ul>
+            </div> --}}
+
+            <div class="relative overflow-x-auto rounded-lg shadow-xl">
+                <table class="w-full text-sm text-left text-gray-500">
+                    <thead class="text-xs text-gray-700 uppercase bg-gray-200">
+                        <tr>
+                            <th scope="col" class="px-6 py-3">
+
+                            </th>
+                            <th scope="col" class="px-6 py-3">
+                                Create
+                            </th>
+                            <th scope="col" class="px-6 py-3">
+                                Read
+                            </th>
+                            <th scope="col" class="px-6 py-3">
+                                Update
+                            </th>
+                            <th scope="col" class="px-6 py-3">
+                                Delete
+                            </th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        @foreach ($permissions as $key => $value)
+                            <tr class="border-b border-gray-200">
+                                <td class="px-6 py-3 font-medium text-gray-700 capitalize">
+                                    {{ $key }}
+                                </td>
+
+                                @foreach ($value as $permissions)
+
+                                    {{-- @dd($permissions['id']) --}}
+                                    <td class="px-6 py-3">
+                                        <x-checkbox name="permissions[]"
+                                                    class="mr-1 !text-blue-600 focus:!ring-blue-500"
+                                                    value="{{ $permissions['id'] }}"
+                                                    :checked="in_array($permissions['id'], old('permissions', []))" />
+                                    </td>
+
+                                @endforeach
+
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
             </div>
 
             <div class="flex justify-between mt-16">

--- a/resources/views/admin/roles/create.blade.php
+++ b/resources/views/admin/roles/create.blade.php
@@ -20,26 +20,7 @@
                          value="{{old('name')}}" />
             </div>
 
-            {{-- <div class="mb-4">
-                <p class="mb-2 font-medium text-sm text-gray-700">Permisos</p>
-                <ul>
-                    @foreach ($permissions as $permission)
-
-                    <li class="mb-2">
-
-                        <x-label>
-                            <x-checkbox name="permissions[]"
-                                        class="mr-1 !text-blue-600 focus:!ring-blue-500"
-                                        value="{{ $permission->id }}"
-                                        :checked="in_array($permission->id, old('permissions', []))"
-                            />
-                                {{ $permission->name }}
-                        </x-label>
-                    @endforeach
-                </ul>
-            </div> --}}
-
-            <div class="relative overflow-x-auto rounded-lg shadow-xl">
+            <div class="relative overflow-x-auto rounded-lg shadow-md">
                 <table class="w-full text-sm text-left text-gray-500">
                     <thead class="text-xs text-gray-700 uppercase bg-gray-200">
                         <tr>
@@ -63,13 +44,11 @@
 
                     <tbody>
                         @foreach ($permissions as $key => $value)
-                            <tr class="border-b border-gray-200">
+                            <tr class="bg-white border-b hover:bg-gray-50">
                                 <td class="px-6 py-3 font-medium text-gray-700 capitalize">
                                     {{ $key }}
                                 </td>
-
                                 @foreach ($value as $permissions)
-
                                     {{-- @dd($permissions['id']) --}}
                                     <td class="px-6 py-3">
                                         <x-checkbox name="permissions[]"
@@ -77,9 +56,7 @@
                                                     value="{{ $permissions['id'] }}"
                                                     :checked="in_array($permissions['id'], old('permissions', []))" />
                                     </td>
-
                                 @endforeach
-
                             </tr>
                         @endforeach
                     </tbody>

--- a/resources/views/admin/roles/create.blade.php
+++ b/resources/views/admin/roles/create.blade.php
@@ -4,20 +4,20 @@
             <h1 class="text-3xl font-bold">Nuevo rol</h1>
         </div>
 
-        <form action="{{ route('admin.roles.store') }}" method="post"
+        <form id="role-form" action="{{ route('admin.roles.store') }}" method="post"
             class="bg-white rounded-lg p-6 shadow-lg">
             @csrf
 
-            <x-validation-errors class="mb-4"/>
-
             <div class="mb-4">
                 <x-label for="name" class="mb-2" value="Nombre" />
-                <x-input name="name"
+                <x-input id="name"
+                         name="name"
                          type="text"
                          required
                          class="block w-full mb-2 focus:!border-blue-500 focus:!ring-blue-500"
                          placeholder="Escribe el nombre del nuevo rol"
                          value="{{old('name')}}" />
+                <x-input-error for="name" class="mt-2" />
             </div>
 
             <div class="relative overflow-x-auto rounded-lg shadow-md">
@@ -77,4 +77,7 @@
 
         </form>
     </div>
+    @push('scripts')
+        <script src="{{Vite::asset('resources/js/roles/validation.js')}}"></script>
+    @endpush
 </x-admin-layout>

--- a/resources/views/admin/roles/edit.blade.php
+++ b/resources/views/admin/roles/edit.blade.php
@@ -21,25 +21,6 @@
                          value="{{old('name', $role->name)}}" />
             </div>
 
-            {{-- <div class="mb-4">
-                <p class="mb-2 font-medium text-sm text-gray-700">Permisos</p>
-                <ul>
-                    @foreach ($permissions as $permission)
-
-                    <li class="mb-2">
-
-                        <x-label>
-                            <x-checkbox name="permissions[]"
-                                        class="mr-1 !text-blue-600 focus:!ring-blue-500"
-                                        value="{{ $permission->id }}"
-                                        :checked="in_array($permission->id, old('permissions', $role->permissions->pluck('id')->toArray()  ))"
-                            />
-                                {{ $permission->name }}
-                        </x-label>
-                    @endforeach
-                </ul>
-            </div> --}}
-
             <div class="relative overflow-x-auto rounded-lg shadow-xl">
                 <table class="w-full text-sm text-left text-gray-500">
                     <thead class="text-xs text-gray-700 uppercase bg-gray-200">
@@ -68,10 +49,7 @@
                                 <td class="px-6 py-3 font-medium text-gray-700 capitalize">
                                     {{ $key }}
                                 </td>
-
                                 @foreach ($value as $permissions)
-
-                                    {{-- @dd($permissions['id']) --}}
                                     <td class="px-6 py-3">
                                         <x-checkbox name="permissions[]"
                                                     class="mr-1 !text-blue-600 focus:!ring-blue-500"
@@ -79,9 +57,7 @@
                                                     :checked="in_array($permissions['id'], old('permissions', []))"
                                                     :checked="in_array($permissions['id'], old('permissions', $role->permissions->pluck('id')->toArray()))" />
                                     </td>
-
                                 @endforeach
-
                             </tr>
                         @endforeach
                     </tbody>

--- a/resources/views/admin/roles/edit.blade.php
+++ b/resources/views/admin/roles/edit.blade.php
@@ -4,7 +4,7 @@
             <h1 class="text-3xl font-bold">Editar rol</h1>
         </div>
 
-        <form action="{{ route('admin.roles.update', $role) }}" method="post"
+        <form id="role-form" action="{{ route('admin.roles.update', $role) }}" method="post"
             class="bg-white rounded-lg p-6 shadow-lg">
             @method('PUT')
             @csrf
@@ -13,12 +13,14 @@
 
             <div class="mb-4">
                 <x-label for="name" class="mb-2" value="Nombre" />
-                <x-input name="name"
+                <x-input id="name"
+                         name="name"
                          type="text"
                          class="block w-full mb-2 focus:!border-blue-500 focus:!ring-blue-500"
                          required
                          placeholder="Escribe un nombre para este rol"
                          value="{{old('name', $role->name)}}" />
+                <x-input-error for="name" class="mt-2" />
             </div>
 
             <div class="relative overflow-x-auto rounded-lg shadow-xl">
@@ -77,4 +79,7 @@
             </div>
         </form>
     </div>
+    @push('scripts')
+        <script src="{{Vite::asset('resources/js/categories/validation.js')}}"></script>
+    @endpush
 </x-admin-layout>

--- a/resources/views/admin/roles/edit.blade.php
+++ b/resources/views/admin/roles/edit.blade.php
@@ -21,7 +21,7 @@
                          value="{{old('name', $role->name)}}" />
             </div>
 
-            <div class="mb-4">
+            {{-- <div class="mb-4">
                 <p class="mb-2 font-medium text-sm text-gray-700">Permisos</p>
                 <ul>
                     @foreach ($permissions as $permission)
@@ -38,6 +38,54 @@
                         </x-label>
                     @endforeach
                 </ul>
+            </div> --}}
+
+            <div class="relative overflow-x-auto rounded-lg shadow-xl">
+                <table class="w-full text-sm text-left text-gray-500">
+                    <thead class="text-xs text-gray-700 uppercase bg-gray-200">
+                        <tr>
+                            <th scope="col" class="px-6 py-3">
+
+                            </th>
+                            <th scope="col" class="px-6 py-3">
+                                Create
+                            </th>
+                            <th scope="col" class="px-6 py-3">
+                                Read
+                            </th>
+                            <th scope="col" class="px-6 py-3">
+                                Update
+                            </th>
+                            <th scope="col" class="px-6 py-3">
+                                Delete
+                            </th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        @foreach ($permissions as $key => $value)
+                            <tr class="border-b border-gray-200">
+                                <td class="px-6 py-3 font-medium text-gray-700 capitalize">
+                                    {{ $key }}
+                                </td>
+
+                                @foreach ($value as $permissions)
+
+                                    {{-- @dd($permissions['id']) --}}
+                                    <td class="px-6 py-3">
+                                        <x-checkbox name="permissions[]"
+                                                    class="mr-1 !text-blue-600 focus:!ring-blue-500"
+                                                    value="{{ $permissions['id'] }}"
+                                                    :checked="in_array($permissions['id'], old('permissions', []))"
+                                                    :checked="in_array($permissions['id'], old('permissions', $role->permissions->pluck('id')->toArray()))" />
+                                    </td>
+
+                                @endforeach
+
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
             </div>
 
             <div class="flex justify-between mt-16">

--- a/resources/views/admin/roles/index.blade.php
+++ b/resources/views/admin/roles/index.blade.php
@@ -1,6 +1,6 @@
 <x-admin-layout>
 
-    <div class="container">
+    <div class="md:container">
         <div class="flex items-center justify-between mb-4">
             <h1 class="text-3xl font-bold">Roles</h1>
             <x-link-button href="{{ route('admin.roles.create') }}" color="blue">
@@ -13,7 +13,7 @@
             <table class="w-full text-sm text-left text-gray-500">
                 <thead class="text-xs text-gray-700 uppercase bg-blue-100">
                     <tr>
-                        <th scope="col" class="px-6 py-3">
+                        <th scope="col" class="px-6 py-3 md:w-1/6 lg:w-1/12">
                             ID
                         </th>
                         <th scope="col" class="px-6 py-3">
@@ -34,7 +34,7 @@
                                 {{ $role->name }}
                             </td>
                             <td class="px-6 py-4">
-                                <a href="{{ route('admin.roles.edit', $role) }}">
+                                <a href="{{ route('admin.roles.edit', $role) }}" class="hover:text-gray-700">
                                     <i class="fa-solid fa-pen"></i>
                                     Editar
                                 </a>
@@ -42,8 +42,8 @@
                                     id='delete-form-{{ $role->id }}'>
                                     @csrf
                                     @method('delete')
-                                    <button type="button" class="text-red-500"
-                                        onclick="deleteRole({{ $role->id }})">
+                                    <button type="button" class="text-rose-500 hover:text-rose-700"
+                                        onclick="destroy({{ $role->id }})">
                                         <i class="fa-solid fa-trash"></i>
                                         Borrar
                                     </button>
@@ -55,19 +55,20 @@
             </table>
         </div>
     </div>
-
     @push('scripts')
         <script>
-            function deleteRole(roleId) {
-                const form = document.querySelector('#delete-form-' + roleId);
+            function destroy(elementId) {
+                const form = document.querySelector('#delete-form-' + elementId);
                 Swal.fire({
                     icon: 'warning',
+                    iconColor: '#f43f5e',
                     title: '¿Estás seguro?',
                     text: "Esta acción es irreversible",
                     showCancelButton: true,
                     confirmButtonText: 'Confirmar',
-                    confirmButtonColor: '#EF4444',
+                    confirmButtonColor: '#f43f5e',
                     cancelButtonText: 'Cancelar',
+                    cancelButtonColor: '#1f2937',
 
                 }).then((result) => {
                     if (result.isConfirmed) {
@@ -77,5 +78,4 @@
             }
         </script>
     @endpush
-
 </x-admin-layout>


### PR DESCRIPTION
Con esta fusión realizo cambios similares a los realizados en los anteriores apartados, para que mantengan un diseño consistente entre ellos e incluir una validación de formulario básica del lado del cliente.

Tras definir permisos apara las acciones de los mopdelos, he visto necesario cambiar la forma en que mostraba los checkboxes para asignarle los permisos a un rol.

Antes se trataba de una lista no numerada con un checkbox por cada permiso definido. Con la cantidad de permisos que disponemos ahora (4 por cada modelo) esta lista numerada se hacía excesivamente extensa

Ahora he organizado estos checkboxes en una tabla de permisos, agrupándolos  por modelo (Categoría, Nivel, Curso...), mejorando significativamente su presentación.

Además, en esta tabla sólo se mostrarán los permisos de los modelos que especifiquemos en el controlador. Así evitamos mostrar otros permisos que no tuvieran relación con las funciones para gestionar los apartados de la aplicación.

Relacionado con los roles y permisos, he decidido renombrar los permisos de edición (antes 'edit') por 'update' para seguir las siglas del acrónimo "CRUD".

![dabaliu test_8000_admin_roles_4_edit(HD Laptop)](https://github.com/edumarrom/pdaw23/assets/73343241/43818d0b-d9b4-4afd-8608-5aef68178db6)
