### PR TITLE
Repasar apartado cursos

### DIFF
--- a/app/Http/Controllers/Admin/CourseController.php
+++ b/app/Http/Controllers/Admin/CourseController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Mail\ApprovedCourse;
 use App\Mail\RejectedCourse;
 use App\Models\Course;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 
@@ -38,19 +37,9 @@ class CourseController extends Controller
 
             Mail::to($course->teacher->email)->send(new ApprovedCourse($course));
 
-            session()->flash('swal', [
-                'icon' => 'success',
-                'title' => '¡Hecho!',
-                'text' => "Curso '$course->title' publicado satisfactoriamente.",
-                'confirmButtonColor' => '#3B82F6',
-            ]);
+            session()->flash('swal', $this->getSwalSuccess("El curso '$course->title' ha sido publicado satisfactoriamente."));
         } else {
-            session()->flash('swal', [
-                'icon' => 'error',
-                'title' => '¡Ups!',
-                'text' => "El curso '$course->title' no cumple los requisitos para ser aprobado.",
-                'confirmButtonColor' => '#3B82F6',
-            ]);
+            session()->flash('swal', $this->getSwalError("El curso '$course->title' no cumple los requisitos para ser aprobado."));
         };
 
         return redirect()->route('admin.courses.index');
@@ -63,13 +52,31 @@ class CourseController extends Controller
 
         Mail::to($course->teacher->email)->send(new RejectedCourse($course));
 
-        session()->flash('swal', [
-            'icon' => 'success',
-            'title' => '¡Hecho!',
-            'text' => "Curso '$course->title' rechazado satisfactoriamente.",
-            'confirmButtonColor' => '#3B82F6',
-        ]);
+        session()->flash('swal', $this->getSwalSuccess("Curso '$course->title' rechazado satisfactoriamente."));
 
         return redirect()->route('admin.courses.index');
+    }
+
+    private function getSwalSuccess($text = '')
+    {
+        return [
+            'icon' => 'success',
+            'title' => '¡Hecho!',
+            'text' => $text,
+            'confirmButtonText' => 'Aceptar',
+            'confirmButtonColor' => '#3B82F6',
+        ];
+    }
+
+    private function getSwalError($text = '')
+    {
+        return [
+            'icon' => 'error',
+            'iconColor' => '#f43f5e',
+            'title' => "D'oh!",
+            'text' => $text,
+            'confirmButtonText' => 'Aceptar',
+            'confirmButtonColor' => '#3B82F6',
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/CourseController.php
+++ b/app/Http/Controllers/Admin/CourseController.php
@@ -11,6 +11,12 @@ use Illuminate\Support\Str;
 
 class CourseController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('can:course-read')->only('index', 'show');
+        $this->middleware('can:course-update')->only('approve', 'reject');
+    }
+
     public function index()
     {
         return view('admin.courses.index');

--- a/app/Livewire/Admin/CoursesIndex.php
+++ b/app/Livewire/Admin/CoursesIndex.php
@@ -18,12 +18,26 @@ class CoursesIndex extends Component
 
     public $status;
 
+    public $search;
+
     public function render()
     {
         $courses = Course::where('status', 'LIKE', '%' . $this->status . '%' )
+            ->where(function ($query) {
+                $query->where('title', 'ILIKE', '%' . $this->search . '%')
+                ->orWhere('id', 'ILIKE', '%' . $this->search . '%')
+                ->orWhereHas('teacher', function ($query) {
+                    $query->where('name', 'ILIKE', '%' . $this->search . '%');
+                });
+            })
             ->orderBy('created_at', 'desc')->orderBy('id', 'desc')
             ->paginate();
 
         return view('livewire.admin.courses-index', compact('courses'));
+    }
+
+    public function updatingSearch()
+    {
+        $this->resetPage();
     }
 }

--- a/resources/views/admin/courses/index.blade.php
+++ b/resources/views/admin/courses/index.blade.php
@@ -28,12 +28,14 @@
                 const form = document.querySelector('#suspend-form-' + courseId);
                 Swal.fire({
                     icon: 'warning',
+                    iconColor: '#f43f5e',
                     title: '¿Estás seguro?',
                     text: "Esta acción es irreversible",
                     showCancelButton: true,
                     confirmButtonText: 'Confirmar',
-                    confirmButtonColor: '#EF4444',
+                    confirmButtonColor: '#f43f5e',
                     cancelButtonText: 'Cancelar',
+                    cancelButtonColor: '#1f2937',
 
                 }).then((result) => {
                     if (result.isConfirmed) {

--- a/resources/views/admin/courses/show.blade.php
+++ b/resources/views/admin/courses/show.blade.php
@@ -22,14 +22,13 @@
                         {{$course->students_count}}
                     </li>
                     <li>
-                        @for ($i = 1; $i <= 5; $i++)
-                            @if ($course->rating >= $i)
-                                <i class="fa-solid fa-star"></i>
-                            @else
-                                <i class="fa-solid fa-star text-gray-500"></i>
-                            @endif
-                        @endfor
-                        ({{$course->rating}})
+                        <i class="fa-solid fa-star text-xl mr-2"></i>
+                        @if ($course->reviews_count > 0)
+                            {{$course->rating}} {{ $course->rating == 1 ? 'estrella' : 'estrellas' }}
+                            ({{ $course->reviews_count }} {{ $course->reviews_count == 1 ? 'valoración' : 'valoraciones' }})
+                        @else
+                            <span>Sin valoraciones</span>
+                        @endif
                     </li>
                 </ul>
             </div>
@@ -130,12 +129,10 @@
                                 <hr/>
                                 <ul>
                                     @foreach ($section->lessons as $lesson)
-                                        <a href="{{-- ruta al visor de lección --}}">
-                                            <li class="flex px-4 py-2 hover:bg-gray-200">
-                                                <i class="fa fa-solid fa-play-circle text-lg mr-2"></i>
-                                                {{ $lesson->title }}
-                                            </li>
-                                        </a>
+                                        <li class="flex px-4 py-2 hover:bg-gray-200 cursor-pointer">
+                                            <i class="fa fa-solid fa-play-circle text-lg mr-2"></i>
+                                            {{ $lesson->title }}
+                                        </li>
                                     @endforeach
                                 </ul>
                             </div>
@@ -153,89 +150,7 @@
 
             </section>
 
-            <section>
-                <h3 class="text-3xl font-bold mt-6 mb-2">
-                    <i class="fa fa-solid fa-comment-dots mr-2"></i>
-                    Opiniones
-                </h3>
-
-                @if ($course->reviews_count > 0)
-                    <div class="mb-2">
-
-                        <div class="px-4 py-2">
-                            <div>
-                                <div class="flex items-center mb-2">
-                                    @for ($i = 1; $i <= 5; $i++)
-                                        @if ($course->rating >= $i)
-                                            <i class="fa fa-solid fa-star text-amber-400"></i>
-                                        @else
-                                            <i class="fa fa-solid fa-star text-gray-400"></i>
-                                        @endif
-                                    @endfor
-                                    <p class="ms-1 text-sm font-medium text-gray-500 dark:text-gray-400">{{ $course->rating }}</p>
-                                    <p class="ms-1 text-sm font-medium text-gray-500 dark:text-gray-400"> de </p>
-                                    <p class="ms-1 text-sm font-medium text-gray-500 dark:text-gray-400">5</p>
-                                    <p class="ml-2 text-sm font-medium text-gray-500 dark:text-gray-400">
-                                        ({{ $course->reviews_count }} {{ $course->reviews_count == 1 ? 'valoración' : 'valoraciones' }})
-                                    </p>
-                                </div>
-
-                                <div>
-                                    @for ($i = 1; $i <= 5; $i++)
-                                        @php
-                                            $ratingCount = $course->reviews->where('rating', '=', $i)->count();
-                                            $ratingCountPercent = $ratingCount * 100 / ($course->reviews->count()? : 1);
-                                        @endphp
-                                        <div class="flex items-center mt-1">
-                                            <span class="text-sm font-medium text-indigo-600">{{ $i }}</span>
-                                            <div class="w-full h-2 mx-4 bg-gray-200 rounded">
-                                                <div class="h-2 bg-amber-400 rounded" style="width: {{ $ratingCountPercent }}%"></div>
-                                            </div>
-                                            <div class="w-0">
-                                                <span class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ round($ratingCountPercent) }}%</span>
-                                            </div>
-                                        </div>
-                                    @endfor
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                @endif
-
-                <div class="card p-0 divide-y-2">
-                    @forelse ($course->reviews as $review)
-
-                        <article class="flex p-4">
-                            <figure class="mr-4">
-                                <img class="h-12 w-12 object-cover rounded-full shadow-lg" src="{{$review->user->profile_photo_url}}" alt="">
-                            </figure>
-                            <div class="flex-1">
-                                <div>
-                                    <h2 class="text-xl font-bold">{{$review->user->name}}</h2>
-                                    <ul class="flex text-sm">
-                                        @for ($i = 1; $i <= 5; $i++)
-                                            @if ($review->rating >= $i)
-                                                <li class="mr-1"><i class="fa fa-solid fa-star text-amber-400"></i></li>
-                                            @else
-                                                <li class="mr-1"><i class="fa fa-solid fa-star text-gray-400"></i></li>
-                                            @endif
-                                        @endfor
-                                    </ul>
-                                    {{$review->comment}}
-                                </div>
-                            </div>
-                        </article>
-                    @empty
-                        <div class="flex items-center justify-center p-4">
-                            <div class="flex flex-col items-center">
-                                <i class="fa-solid fa-star text-8xl text-gray-200 mb-6"></i>
-                                <h3 class="text-lg font-bold text-gray-500">Este curso aún no ha recibido opiniones</h3>
-                            </div>
-                        </div>
-                    @endforelse
-                </div>
-            </section>
+            @livewire('courses-reviews', ['course' => $course])
         </div>
 
         {{-- Columna derecha --}}
@@ -324,7 +239,8 @@
                                     Aprobar
                                 </x-button>
                             @else
-                                <x-button type="button" disabled class="w-full justify-center rounded-md !text-sm h-12 mt-4">
+                                <x-button type="button" disabled title="No cumple los requisitos para ser aprobado"
+                                        class="w-full justify-center rounded-md !text-sm h-12 mt-4">
                                     Aprobar
                                 </x-button>
                             @endif

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -22,8 +22,8 @@
                         {{$course->students_count}}
                     </li>
                     <li>
+                        <i class="fa-solid fa-star text-xl mr-2"></i>
                         @if ($course->reviews_count > 0)
-                            <i class="fa-solid fa-star text-xl mr-2"></i>
                             {{$course->rating}} {{ $course->rating == 1 ? 'estrella' : 'estrellas' }}
                             ({{ $course->reviews_count }} {{ $course->reviews_count == 1 ? 'valoración' : 'valoraciones' }})
                         @else

--- a/resources/views/livewire/admin/courses-index.blade.php
+++ b/resources/views/livewire/admin/courses-index.blade.php
@@ -67,13 +67,13 @@
                         <th scope="col" class="px-6 py-3">
                             Título
                         </th>
-                        <th scope="col" class="wpx-6 py-3">
+                        <th scope="col" class="px-6 py-3">
                             Profesor
                         </th>
-                        <th scope="col" class="wpx-6 py-3">
+                        <th scope="col" class="px-6 py-3">
                             Estado
                         </th>
-                        <th scope="col" class="wpx-6 py-3 md:w-1/3 lg:w-1/12">
+                        <th scope="col" class="px-6 py-3 md:w-1/3 lg:w-1/12">
                             Acciones
                         </th>
                     </tr>
@@ -110,7 +110,7 @@
                                     @default
                                 @endswitch
                             </td>
-                            <td class="px-6 py-4">
+                            <td class="px-4 py-2">
                                 @switch($course->status)
                                     @case(2)
                                         <x-link-button href="{{ route('admin.courses.show', $course) }}"

--- a/resources/views/livewire/admin/courses-index.blade.php
+++ b/resources/views/livewire/admin/courses-index.blade.php
@@ -1,113 +1,163 @@
 <div>
 
-    <div class="relative overflow-x-auto rounded-lg shadow-xl">
-        <table class="w-full text-sm text-left text-gray-500">
-            <thead class="text-xs text-gray-700 uppercase bg-blue-100">
-                <tr class="bg-blue-200 border-b border-gray-300">
-                    <td colspan="3" class="px-6 py-3">
+    <div class="card rounded-lg shadow-md mb-4">
+        <div class="flex items-center justify-between flex-column {{-- flex-wrap --}} " >
+            <label for="table-search" class="sr-only">Buscar</label>
+            <div class="relative w-full mr-4">
+                <div class="absolute inset-y-0 rtl:inset-r-0 start-0 flex items-center ps-3 pointer-events-none">
+                    <i class="fa fa-solid fa-search text-gray-500"></i>
+                </div>
+                <input id="table-search-courses" type="search" wire:model.live.debounce.750ms="search" placeholder="Buscar un curso"
+                    class="block p-2 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg w-full focus:ring-blue-500 focus:border-blue-500">
+            </div>
+            <div>
+                <x-dropdown align="right">
+                    <x-slot name="trigger">
+                        <span class="inline-flex rounded-md">
+                            {{-- inline-flex items-center bg-white text-gray-700 rounded shadow h-10 px-4 --}}
+                            <button class="py-2 px-4 inline-flex items-center text-sm text-gray-900 border border-gray-300 rounded-lg w-full focus:ring-blue-500 focus:border-blue-500">
+                                @switch($status)
+                                    @case('')
+                                        Estado
+                                        @break
+                                    @case(1)
+                                        Borrador
+                                        @break
+                                    @case(2)
+                                        Pendiente
+                                        @break
+                                    @case(3)
+                                        Publicado
+                                        @break
+                                    @default
+                                @endswitch
 
-                        <div class="relative">
-                            <div class="absolute inset-y-0 rtl:inset-r-0 start-0 flex items-center ps-3 pointer-events-none">
-                                <i class="fa fa-solid fa-search text-gray-500"></i>
-                            </div>
-                            <input id="table-search-users" type="search" wire:model.live.debounce.750ms="search" placeholder="Buscar un curso"
-                                class="block p-2 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg w-full focus:ring-blue-500 focus:border-blue-500">
-                        </div>
+                                <svg class="ms-2 -me-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                                </svg>
+                            </button>
+                        </span>
+                    </x-slot>
 
-                    </td>
-                    <td class="px-6 py-3">
-                        <x-select id="status"
-                                name="status"
-                                class="block w-full"
-                                wire:model.live="status">
-                            <option value="">Todos</option>
-                            @foreach ($statuses as $status)
-                                <option value="{{ $status['id'] }}">{{ $status['name'] }}</option>
-                            @endforeach
-                        </x-select>
-                    </td class="px-6 py-3">
-                    <td class="px-6 py-3"></td>
-                </tr>
-                <tr>
-                    <th scope="col" class="px-6 py-3">
-                        ID
-                    </th>
-                    <th scope="col" class="px-6 py-3">
-                        Título
-                    </th>
-                    <th scope="col" class="wpx-6 py-3">
-                        Profesor
-                    </th>
-                    <th scope="col" class="wpx-6 py-3">
-                        Estado
-                    </th>
-                    <th scope="col" class="wpx-6 py-3 md:w-1/3 lg:w-1/12">
-                        Acciones
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach ($courses as $course)
-                    <tr class="bg-white border-b hover:bg-gray-50">
-                        <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap">
-                            {{ $course->id }}
+                    <x-slot name="content">
+                        <x-dropdown-link class="cursor-pointer"
+                            wire:click="$set('status', '')">
+                            Todos
+                        </x-dropdown-link>
+                        @foreach ($statuses as $status)
+                            <x-dropdown-link class="cursor-pointer"
+                                wire:click="$set('status', {{$status['id']}})">
+                                {{ $status['name'] }}
+                            </x-dropdown-link>
+                        @endforeach
+                    </x-slot>
+                </x-dropdown>
+            </div>
+        </div>
+    </div>
+
+    @if ($courses->count())
+        <div class="relative overflow-x-auto rounded-lg shadow-xl">
+            <table class="w-full text-sm text-left text-gray-500">
+                <thead class="text-xs text-gray-700 uppercase bg-blue-100">
+                    <tr>
+                        <th scope="col" class="px-6 py-3">
+                            ID
                         </th>
-                        <td class="px-6 py-4">
-                            {{ $course->title }}
-                        </td>
-                        <td class="px-6 py-4">
-                            {{ $course->teacher->name }}
-                        </td>
-                        <td class="px-6 py-4">
-                            @switch($course->status)
-                                @case(1)
-                                    <div class="flex items-center">
-                                        <div class="h-2.5 w-2.5 rounded-full bg-rose-500 me-2"></div> Borrador
-                                    </div>
-                                    @break
-                                @case(2)
-                                    <div class="flex items-center">
-                                        <div class="h-2.5 w-2.5 rounded-full bg-amber-500 me-2"></div> Pendiente
-                                    </div>
-                                    @break
-                                @case(3)
-                                    <div class="flex items-center">
-                                        <div class="h-2.5 w-2.5 rounded-full bg-green-500 me-2"></div> Publicado
-                                    </div>
-                                    @break
-                                @default
-                            @endswitch
-                        </td>
-                        <td class="px-6 py-4">
-                            @switch($course->status)
-                                @case(2)
-                                    <x-link-button href="{{ route('admin.courses.show', $course) }}"
-                                            color="blue" class="w-full justify-center">
-                                        <i class="fa-solid fa-eye mr-1"></i>
-                                        Revisar
-                                    </x-link-button>
-                                    @break
-                                @case(3)
-                                    <form action="{{ route('admin.courses.reject', $course) }}" method="post"
-                                            id="suspend-form-{{ $course->id }}">
-                                        @csrf
-                                        <x-button type="button" color="rose" class="w-full justify-center"
-                                                onclick="suspendCourse({{ $course->id }})">
-                                            <i class="fa-solid fa-eye-slash"></i>
-                                            Suspender
-                                        </x-button>
-                                    </form>
-                                    @break
-                                @default
-                            @endswitch
-                        </td>
+                        <th scope="col" class="px-6 py-3">
+                            Título
+                        </th>
+                        <th scope="col" class="wpx-6 py-3">
+                            Profesor
+                        </th>
+                        <th scope="col" class="wpx-6 py-3">
+                            Estado
+                        </th>
+                        <th scope="col" class="wpx-6 py-3 md:w-1/3 lg:w-1/12">
+                            Acciones
+                        </th>
                     </tr>
-                @endforeach
-            </tbody>
-        </table>
-    </div>
+                </thead>
+                <tbody>
+                    @foreach ($courses as $course)
+                        <tr class="bg-white border-b hover:bg-gray-50">
+                            <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap">
+                                {{ $course->id }}
+                            </th>
+                            <td class="px-6 py-4">
+                                {{ $course->title }}
+                            </td>
+                            <td class="px-6 py-4">
+                                {{ $course->teacher->name }}
+                            </td>
+                            <td class="px-6 py-4">
+                                @switch($course->status)
+                                    @case(1)
+                                        <div class="flex items-center">
+                                            <div class="h-2.5 w-2.5 rounded-full bg-rose-500 me-2"></div> Borrador
+                                        </div>
+                                        @break
+                                    @case(2)
+                                        <div class="flex items-center">
+                                            <div class="h-2.5 w-2.5 rounded-full bg-amber-500 me-2"></div> Pendiente
+                                        </div>
+                                        @break
+                                    @case(3)
+                                        <div class="flex items-center">
+                                            <div class="h-2.5 w-2.5 rounded-full bg-green-500 me-2"></div> Publicado
+                                        </div>
+                                        @break
+                                    @default
+                                @endswitch
+                            </td>
+                            <td class="px-6 py-4">
+                                @switch($course->status)
+                                    @case(2)
+                                        <x-link-button href="{{ route('admin.courses.show', $course) }}"
+                                                color="blue" class="w-full justify-center">
+                                            <i class="fa-solid fa-eye mr-1"></i>
+                                            Revisar
+                                        </x-link-button>
+                                        @break
+                                    @case(3)
+                                        <form action="{{ route('admin.courses.reject', $course) }}" method="post"
+                                                id="suspend-form-{{ $course->id }}">
+                                            @csrf
+                                            <x-button type="button" color="rose" class="w-full justify-center"
+                                                    onclick="suspendCourse({{ $course->id }})">
+                                                <i class="fa-solid fa-eye-slash"></i>
+                                                Suspender
+                                            </x-button>
+                                        </form>
+                                        @break
+                                    @default
+                                @endswitch
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
 
-    <div class="mt-6">
-        {{ $courses->links() }}
-    </div>
+        <div class="mt-6">
+            {{ $courses->links() }}
+        </div>
+    @else
+        <div class="flex items-center justify-center p-4">
+            <div class="flex flex-col items-center">
+                @if ($search)
+                    <i class="fa-regular fa-face-sad-tear text-8xl text-gray-300 mb-6"></i>
+                    <h3 class="text-lg font-bold text-gray-600">
+                        No hay cursos que coincidan con "{{ $search }}".
+                    </h3>
+                @else
+                    {{-- <img class="w-64 h-auto mb-4" src="{{ asset('img/tumbleweed.png') }}" alt=""> --}}
+                    <i class="fa-solid fa-cloud-moon text-8xl text-gray-300 mb-6"></i>
+                    <h3 class="text-lg font-bold text-gray-600">
+                            Esto está muy tranquilo. Demasiado...
+                    </h3>
+                @endif
+            </div>
+        </div>
+    @endif
 </div>

--- a/resources/views/livewire/admin/courses-index.blade.php
+++ b/resources/views/livewire/admin/courses-index.blade.php
@@ -4,9 +4,17 @@
         <table class="w-full text-sm text-left text-gray-500">
             <thead class="text-xs text-gray-700 uppercase bg-blue-100">
                 <tr class="bg-blue-200 border-b border-gray-300">
-                    <td class="px-6 py-3"></td>
-                    <td class="px-6 py-3"></td>
-                    <td class="px-6 py-3"></td>
+                    <td colspan="3" class="px-6 py-3">
+
+                        <div class="relative">
+                            <div class="absolute inset-y-0 rtl:inset-r-0 start-0 flex items-center ps-3 pointer-events-none">
+                                <i class="fa fa-solid fa-search text-gray-500"></i>
+                            </div>
+                            <input id="table-search-users" type="search" wire:model.live.debounce.750ms="search" placeholder="Buscar un curso"
+                                class="block p-2 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg w-full focus:ring-blue-500 focus:border-blue-500">
+                        </div>
+
+                    </td>
                     <td class="px-6 py-3">
                         <x-select id="status"
                                 name="status"


### PR DESCRIPTION
Con esta fusión modifico el apartado de cursos al igual que los anteriores para que mantengan un diseño consistente.

He incluido un buscador de cursos para facilitar la localización de cursos. Pueden buscarse por título, nombre del profesor o ID del curso. El buscador se puede combinar con el filtro de estado.

He cambiado el filtro de estado. Ahora en lugar de ser un selector de formulario he incluido un componente desplegable.

Ambos elementos, buscador y filtrado, ahora se encuentran fuera de la tabla. Si una busqueda no devuelve resultados, o si no hay cursos para mostrar, se muestra un mensaje informando al usuario.

![dabaliu test_8000_admin_courses(HD Laptop) (2)](https://github.com/edumarrom/pdaw23/assets/73343241/8633820c-7e82-4b20-8ce9-383c7e70cafd)
