### PR TITLE
Simplificar el controlador de cursos

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -12,25 +12,9 @@ class CourseController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function __invoke()
     {
         return view('courses.index');
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
     }
 
     /**
@@ -41,30 +25,6 @@ class CourseController extends Controller
         $this->authorize('published', $course);
 
         return view('courses.show', compact('course'));
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(Course $course)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, Course $course)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(Course $course)
-    {
-        //
     }
 
     public function enroll(Course $course) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,11 +19,15 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', HomeController::class)->name('home');
 
+Route::get('courses', CourseController::class)
+    ->name('courses.index');
+
 Route::get('courses/my-courses', MyCourses::class)
     ->middleware('auth')
     ->name('courses.my-courses');
 
-Route::resource('courses', CourseController::class)->names('courses');
+Route::get('courses/{course}', [CourseController::class, 'show'])
+    ->name('courses.show');
 
 Route::post('courses/{course}/enroll', [CourseController::class, 'enroll'])
     ->middleware('auth')


### PR DESCRIPTION
Con esta fusión cambio la forma en que se definen las rutas para el catálogo y la ficha de cursos.

Antes era una ruta de tipo `resource` a la que sólo le habíamos implementado los métodos `index` y `show`.

He eliminado los métodos no implementados del controlador, y sustituido la ruta `resource` por dos rutas independientes:

- Una sin indicar el método, ya que el método `index` lo he renombrado como el método mágico `__invoke`.
- Otra para el método `show` que nos muestra la ficha del curso.